### PR TITLE
fix(nextjs): update next-auth to beta version to resolve build failure

### DIFF
--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -19,7 +19,7 @@
     "@types/three": "^0.183.1",
     "argon2": "^0.41.1",
     "next": "14.2.29",
-    "next-auth": "^5.0.0",
+    "next-auth": "^5.0.0-beta.30",
     "@auth/prisma-adapter": "^2.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",


### PR DESCRIPTION
package.jsonの  "next-auth": "^5.0.0-beta.30",を追加