### PR TITLE
fix(auth): correct next-auth version and prisma client import

### DIFF
--- a/nextjs/auth.ts
+++ b/nextjs/auth.ts
@@ -1,7 +1,7 @@
 import NextAuth from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import { PrismaAdapter } from "@auth/prisma-adapter";
-import prisma from "@/lib/prisma";
+import { prisma } from "@/lib/prisma";
 import argon2 from "argon2";
 import GitHub from "next-auth/providers/github";
 import Google from "next-auth/providers/google";


### PR DESCRIPTION
サーバーエラーの原因だった PrismaClient のインポートミスを修正。