### PR TITLE
打ち手が下から上に攻めるのをデフォルトにした

### DIFF
--- a/nextjs/app/home/page.tsx
+++ b/nextjs/app/home/page.tsx
@@ -57,7 +57,7 @@ export default function HomePage() {
 						<div className="wafuu-menu-text">
 							<div className="wafuu-menu-title">AI対戦</div>
 							<div className="wafuu-menu-desc">
-								コンピュータと練習しよう（準備中）
+								コンピュータと練習しよう
 							</div>
 						</div>
 						<span className="wafuu-menu-arrow">→</span>

--- a/nextjs/components/AiMatchBoard.tsx
+++ b/nextjs/components/AiMatchBoard.tsx
@@ -284,7 +284,7 @@ function AiMatchBoard({ mySide = "sente", aiDepth = 4, isPreparing = false }: Ai
 							</div>
 						)}
 
-						{/* Gote player info + hand (右上) */}
+						{/* 右上 (AI / 対戦相手) */}
 						<div
 							style={{
 								position: "fixed",
@@ -309,13 +309,22 @@ function AiMatchBoard({ mySide = "sente", aiDepth = 4, isPreparing = false }: Ai
 								backdropFilter: "blur(12px)",
 								boxShadow: "0 4px 15px rgba(0,0,0,0.4)"
 							}}>
-								<span style={{ color: "#f5e6c8", fontSize: "0.95rem", fontWeight: 600, letterSpacing: "0.02em" }}>{mySide === "gote" ? "あなた" : "AI 🤖"}</span>
-								<span className="board-player-badge badge-gote" style={{ fontSize: "0.75rem", padding: "2px 8px", borderRadius: "12px", fontWeight: 700 }}>後手</span>
+								{mySide === "sente" ? (
+									<>
+										<span style={{ color: "#f5e6c8", fontSize: "0.95rem", fontWeight: 600, letterSpacing: "0.02em" }}>AI 🤖</span>
+										<span className="board-player-badge badge-gote" style={{ fontSize: "0.75rem", padding: "2px 8px", borderRadius: "12px", fontWeight: 700 }}>後手</span>
+									</>
+								) : (
+									<>
+										<span className="board-player-badge badge-sente" style={{ fontSize: "0.75rem", padding: "2px 8px", borderRadius: "12px", fontWeight: 700 }}>先手</span>
+										<span style={{ color: "#f5e6c8", fontSize: "0.95rem", fontWeight: 600, letterSpacing: "0.02em" }}>AI 🤖</span>
+									</>
+								)}
 							</div>
 						</div>
 
 
-						{/* Sente player info + hand (左下) */}
+						{/* 左下 (あなた) */}
 						<div
 							style={{
 								position: "fixed",
@@ -340,8 +349,17 @@ function AiMatchBoard({ mySide = "sente", aiDepth = 4, isPreparing = false }: Ai
 								backdropFilter: "blur(12px)",
 								boxShadow: "0 4px 15px rgba(0,0,0,0.4)"
 							}}>
-								<span className="board-player-badge badge-sente" style={{ fontSize: "0.75rem", padding: "2px 8px", borderRadius: "12px", fontWeight: 700 }}>先手</span>
-								<span style={{ color: "#f5e6c8", fontSize: "0.95rem", fontWeight: 600, letterSpacing: "0.02em" }}>{mySide === "sente" ? "あなた" : "AI 🤖"}</span>
+								{mySide === "gote" ? (
+									<>
+										<span style={{ color: "#f5e6c8", fontSize: "0.95rem", fontWeight: 600, letterSpacing: "0.02em" }}>あなた</span>
+										<span className="board-player-badge badge-gote" style={{ fontSize: "0.75rem", padding: "2px 8px", borderRadius: "12px", fontWeight: 700 }}>後手</span>
+									</>
+								) : (
+									<>
+										<span className="board-player-badge badge-sente" style={{ fontSize: "0.75rem", padding: "2px 8px", borderRadius: "12px", fontWeight: 700 }}>先手</span>
+										<span style={{ color: "#f5e6c8", fontSize: "0.95rem", fontWeight: 600, letterSpacing: "0.02em" }}>あなた</span>
+									</>
+								)}
 							</div>
 						</div>
 

--- a/nextjs/components/MatchBoard.tsx
+++ b/nextjs/components/MatchBoard.tsx
@@ -304,7 +304,7 @@ function MatchBoard({ roomId, socket, wsStatus = "disconnected", mySide = "sente
 							</div>
 						)}
 
-						{/* Gote player info (右上) */}
+						{/* 右上 (対戦相手の情報) */}
 						<div
 							style={{
 								position: "fixed",
@@ -329,12 +329,21 @@ function MatchBoard({ roomId, socket, wsStatus = "disconnected", mySide = "sente
 								backdropFilter: "blur(12px)",
 								boxShadow: "0 4px 15px rgba(0,0,0,0.4)"
 							}}>
-								<span style={{ color: "#f5e6c8", fontSize: "0.95rem", fontWeight: 600, letterSpacing: "0.02em" }}>{mySide === "gote" ? "あなた" : "対戦相手"}</span>
-								<span className="board-player-badge badge-gote" style={{ fontSize: "0.75rem", padding: "2px 8px", borderRadius: "12px", fontWeight: 700 }}>後手</span>
+								{mySide === "sente" ? (
+									<>
+										<span style={{ color: "#f5e6c8", fontSize: "0.95rem", fontWeight: 600, letterSpacing: "0.02em" }}>対戦相手</span>
+										<span className="board-player-badge badge-gote" style={{ fontSize: "0.75rem", padding: "2px 8px", borderRadius: "12px", fontWeight: 700 }}>後手</span>
+									</>
+								) : (
+									<>
+										<span className="board-player-badge badge-sente" style={{ fontSize: "0.75rem", padding: "2px 8px", borderRadius: "12px", fontWeight: 700 }}>先手</span>
+										<span style={{ color: "#f5e6c8", fontSize: "0.95rem", fontWeight: 600, letterSpacing: "0.02em" }}>対戦相手</span>
+									</>
+								)}
 							</div>
 						</div>
 
-						{/* Sente player info (左下) */}
+						{/* 左下 (あなたの情報) */}
 						<div
 							style={{
 								position: "fixed",
@@ -359,8 +368,17 @@ function MatchBoard({ roomId, socket, wsStatus = "disconnected", mySide = "sente
 								backdropFilter: "blur(12px)",
 								boxShadow: "0 4px 15px rgba(0,0,0,0.4)"
 							}}>
-								<span className="board-player-badge badge-sente" style={{ fontSize: "0.75rem", padding: "2px 8px", borderRadius: "12px", fontWeight: 700 }}>先手</span>
-								<span style={{ color: "#f5e6c8", fontSize: "0.95rem", fontWeight: 600, letterSpacing: "0.02em" }}>{mySide === "sente" ? "あなた" : "対戦相手"}</span>
+								{mySide === "gote" ? (
+									<>
+										<span style={{ color: "#f5e6c8", fontSize: "0.95rem", fontWeight: 600, letterSpacing: "0.02em" }}>あなた</span>
+										<span className="board-player-badge badge-gote" style={{ fontSize: "0.75rem", padding: "2px 8px", borderRadius: "12px", fontWeight: 700 }}>後手</span>
+									</>
+								) : (
+									<>
+										<span className="board-player-badge badge-sente" style={{ fontSize: "0.75rem", padding: "2px 8px", borderRadius: "12px", fontWeight: 700 }}>先手</span>
+										<span style={{ color: "#f5e6c8", fontSize: "0.95rem", fontWeight: 600, letterSpacing: "0.02em" }}>あなた</span>
+									</>
+								)}
 							</div>
 						</div>
 
@@ -466,7 +484,7 @@ function MatchBoard({ roomId, socket, wsStatus = "disconnected", mySide = "sente
 										fontSize: "4.5rem",
 										fontWeight: 900,
 										letterSpacing: "0.2em",
-										color: gameResult.winner === mySide ? "#d4af37" : "#888",
+										color: gameResult.winner === mySide ? "#d4af37" : (gameResult.winner === null ? "#f5e6c8" : "#888"),
 										textShadow: gameResult.winner === mySide
 											? "0 0 40px rgba(212, 175, 55, 0.6)"
 											: "0 0 20px rgba(255, 255, 255, 0.1)",
@@ -474,7 +492,7 @@ function MatchBoard({ roomId, socket, wsStatus = "disconnected", mySide = "sente
 										fontFamily: "'M PLUS Rounded 1c', sans-serif"
 									}}
 								>
-									{gameResult.winner === mySide ? "勝利" : (gameResult.winner === null ? "引き分け" : "敗北")}
+									{mySide === "spectator" ? "対局終了" : (gameResult.winner === mySide ? "勝利" : (gameResult.winner === null ? "引き分け" : "敗北"))}
 								</h2>
 
 								<p

--- a/nextjs/components/TatamiBackground.tsx
+++ b/nextjs/components/TatamiBackground.tsx
@@ -454,16 +454,18 @@ const BOARD_Z_COORDS = [-6.4, -3.2, 0, 3.2, 6.4];
 const BOARD_Y = 10.0;       // 駒の Y 座標（高さ）
 
 // グリッド座標 → 3D ワールド座標
-function gridToWorld(row: number, col: number): [number, number, number] {
+function gridToWorld(row: number, col: number, isFlipped: boolean = false): [number, number, number] {
+	const r = isFlipped ? 4 - row : row;
+	const c = isFlipped ? 4 - col : col;
 	return [
-		BOARD_X_COORDS[row],
+		BOARD_X_COORDS[r],
 		BOARD_Y,
-		BOARD_Z_COORDS[col]
+		BOARD_Z_COORDS[c]
 	];
 }
 
 // 3D ワールド座標 → 最も近いグリッド座標
-function worldToGrid(x: number, z: number): { row: number; col: number } | null {
+function worldToGrid(x: number, z: number, isFlipped: boolean = false): { row: number; col: number } | null {
 	// 最も近いX座標のインデックスを探す
 	let bestRow = 0;
 	let minXDist = Math.abs(x - BOARD_X_COORDS[0]);
@@ -486,6 +488,9 @@ function worldToGrid(x: number, z: number): { row: number; col: number } | null 
 		}
 	}
 
+	if (isFlipped) {
+		return { row: 4 - bestRow, col: 4 - bestCol };
+	}
 	return { row: bestRow, col: bestCol };
 }
 
@@ -606,6 +611,9 @@ export default function TatamiBackground({
 		return initial;
 	});
 
+	// 盤面の向き：自分が後手(White)の場合は論理的な座標を反転させる
+	const isFlipped = useMemo(() => playerColor === Color.WHITE, [playerColor]);
+
 
 
 
@@ -622,9 +630,9 @@ export default function TatamiBackground({
 		if (capturedPiece) {
 			const capturedId = Object.keys(PIECE_INITIAL_GRID).find(pid => {
 				if (pid === id) return false;
-				const pPos = piecePositions[pid] || gridToWorld(PIECE_INITIAL_GRID[pid].row, PIECE_INITIAL_GRID[pid].col);
+				const pPos = piecePositions[pid] || gridToWorld(PIECE_INITIAL_GRID[pid].row, PIECE_INITIAL_GRID[pid].col, isFlipped);
 				if (checkIsHandPos(pPos)) return false;
-				const pg = worldToGrid(pPos[0], pPos[2]);
+				const pg = worldToGrid(pPos[0], pPos[2], isFlipped);
 				return pg && pg.row === toGrid.row && pg.col === toGrid.col;
 			});
 			if (capturedId) {
@@ -639,14 +647,14 @@ export default function TatamiBackground({
 
 		setPiecePositions(prev => {
 			const nextPosMap = { ...prev };
-			nextPosMap[id] = gridToWorld(toGrid.row, toGrid.col);
+			nextPosMap[id] = gridToWorld(toGrid.row, toGrid.col, isFlipped);
 
 			if (capturedPiece) {
 				const capturedId = Object.keys(PIECE_INITIAL_GRID).find(pid => {
 					if (pid === id) return false;
-					const pPos = prev[pid] || gridToWorld(PIECE_INITIAL_GRID[pid].row, PIECE_INITIAL_GRID[pid].col);
+					const pPos = prev[pid] || gridToWorld(PIECE_INITIAL_GRID[pid].row, PIECE_INITIAL_GRID[pid].col, isFlipped);
 					if (checkIsHandPos(pPos)) return false;
-					const pg = worldToGrid(pPos[0], pPos[2]);
+					const pg = worldToGrid(pPos[0], pPos[2], isFlipped);
 					return pg && pg.row === toGrid.row && pg.col === toGrid.col;
 				});
 
@@ -661,7 +669,7 @@ export default function TatamiBackground({
 		});
 
 		setBoardState(nextState);
-	}, [boardState, piecePositions, pieceOwners]);
+	}, [boardState, piecePositions, pieceOwners, isFlipped]);
 
 	// 駒が操作可能かどうかを判定（自分の手番かつ自分の駒であること）
 	const isPieceDraggable = useCallback((id: string) => {
@@ -710,16 +718,16 @@ export default function TatamiBackground({
 		if (move.type === "move") {
 			// 盤上移動の場合: move.from にある駒を探す
 			targetId = Object.keys(PIECE_INITIAL_GRID).find(id => {
-				const pos = piecePositions[id] || gridToWorld(PIECE_INITIAL_GRID[id].row, PIECE_INITIAL_GRID[id].col);
+				const pos = piecePositions[id] || gridToWorld(PIECE_INITIAL_GRID[id].row, PIECE_INITIAL_GRID[id].col, isFlipped);
 				if (checkIsHandPos(pos)) return false;
-				const grid = worldToGrid(pos[0], pos[2]);
+				const grid = worldToGrid(pos[0], pos[2], isFlipped);
 				return grid && grid.row === move.from.row && grid.col === move.from.col;
 			}) || null;
 		} else if (move.type === "drop") {
 			// 打ち込みの場合: 現在の手番의持ち駒の中から同じ種類かつ駒台にあるものを探す
 			const owner = boardState.sideToMove;
 			targetId = Object.keys(PIECE_INITIAL_GRID).find(id => {
-				const pos = piecePositions[id] || gridToWorld(PIECE_INITIAL_GRID[id].row, PIECE_INITIAL_GRID[id].col);
+				const pos = piecePositions[id] || gridToWorld(PIECE_INITIAL_GRID[id].row, PIECE_INITIAL_GRID[id].col, isFlipped);
 				return checkIsHandPos(pos) && pieceOwners[id] === owner && getBasePieceType(id) === move.pieceType;
 			}) || null;
 		}
@@ -732,14 +740,18 @@ export default function TatamiBackground({
 
 	// 駒の向きを計算するヘルパー
 	const getPieceRotation = (id: string, color: Color, isPromoted: boolean): [number, number, number] => {
-		const isSente = color === Color.BLACK;
 		const isFu = id.includes("fu");
 		let rotation: [number, number, number];
+
+		// 視点が反転している場合、駒の向き（基本向き）も反転させる
+		const visualColor = isFlipped ? (color === Color.BLACK ? Color.WHITE : Color.BLACK) : color;
+		const isVisualSente = visualColor === Color.BLACK;
+
 		// 歩兵(fu.glb)だけモデルの基本向きが違うため調整
 		if (isFu) {
-			rotation = isSente ? [Math.PI / 2, 0, -Math.PI / 2] : [-Math.PI / 2, Math.PI, -Math.PI / 2];
+			rotation = isVisualSente ? [Math.PI / 2, 0, -Math.PI / 2] : [-Math.PI / 2, Math.PI, -Math.PI / 2];
 		} else {
-			rotation = isSente ? [-Math.PI / 2, 0, -Math.PI / 2] : [Math.PI / 2, Math.PI, -Math.PI / 2];
+			rotation = isVisualSente ? [-Math.PI / 2, 0, -Math.PI / 2] : [Math.PI / 2, Math.PI, -Math.PI / 2];
 		}
 
 		// 成っている場合は裏返しにする(X軸180度回転)
@@ -770,28 +782,28 @@ export default function TatamiBackground({
 
 	// その持ち駒の種類の中で、表示されるべき代表駒かどうかを判定（重複表示防止）
 	const isPrimaryHandPiece = useCallback((id: string): boolean => {
-		const pos = piecePositions[id] || gridToWorld(PIECE_INITIAL_GRID[id].row, PIECE_INITIAL_GRID[id].col);
+		const pos = piecePositions[id] || gridToWorld(PIECE_INITIAL_GRID[id].row, PIECE_INITIAL_GRID[id].col, isFlipped);
 		if (!checkIsHandPos(pos)) return true;
 
 		const owner = pieceOwners[id];
 		const type = getBasePieceType(id);
 		// 同じ種類かつ同じ所有者の駒リストを取得
 		const sameTypeIds = Object.keys(PIECE_INITIAL_GRID).filter(pid => {
-			const pPos = piecePositions[pid] || gridToWorld(PIECE_INITIAL_GRID[pid].row, PIECE_INITIAL_GRID[pid].col);
+			const pPos = piecePositions[pid] || gridToWorld(PIECE_INITIAL_GRID[pid].row, PIECE_INITIAL_GRID[pid].col, isFlipped);
 			return checkIsHandPos(pPos) && pieceOwners[pid] === owner && getBasePieceType(pid) === type;
 		});
 		// リストの先頭のIDだけを代表とする
 		return sameTypeIds[0] === id;
-	}, [piecePositions, pieceOwners]);
+	}, [piecePositions, pieceOwners, isFlipped]);
 
 	// 現在の選択駒に対する有効な移動先を計算
 	const validMoveDestinations = useMemo(() => {
 		if (!selectedPiece) return [];
 
 		// 現在のグリッド位置を特定
-		const currentPos = piecePositions[selectedPiece] || gridToWorld(PIECE_INITIAL_GRID[selectedPiece].row, PIECE_INITIAL_GRID[selectedPiece].col);
+		const currentPos = piecePositions[selectedPiece] || gridToWorld(PIECE_INITIAL_GRID[selectedPiece].row, PIECE_INITIAL_GRID[selectedPiece].col, isFlipped);
 		const isHand = checkIsHandPos(currentPos);
-		const fromGrid = worldToGrid(currentPos[0], currentPos[2]);
+		const fromGrid = worldToGrid(currentPos[0], currentPos[2], isFlipped);
 		if (!fromGrid && !isHand) return [];
 
 		// そのマスに現在の手番の駒があるか確認（駒台の場合は所有者を確認）
@@ -813,10 +825,10 @@ export default function TatamiBackground({
 	}, [selectedPiece, boardState, piecePositions, pieceOwners]);
 
 	const handleDragEnd = useCallback((id: string, newPos: [number, number, number]) => {
-		const toGrid = worldToGrid(newPos[0], newPos[2]);
+		const toGrid = worldToGrid(newPos[0], newPos[2], isFlipped);
 		if (!toGrid) return;
 
-		const currentPos = piecePositions[id] || gridToWorld(PIECE_INITIAL_GRID[id].row, PIECE_INITIAL_GRID[id].col);
+		const currentPos = piecePositions[id] || gridToWorld(PIECE_INITIAL_GRID[id].row, PIECE_INITIAL_GRID[id].col, isFlipped);
 		const isFromHand = checkIsHandPos(currentPos);
 
 		let move: Move;
@@ -830,7 +842,7 @@ export default function TatamiBackground({
 			};
 		} else {
 			// 盤上の移動
-			const fromGrid = worldToGrid(currentPos[0], currentPos[2]);
+			const fromGrid = worldToGrid(currentPos[0], currentPos[2], isFlipped);
 			if (fromGrid.row === toGrid.row && fromGrid.col === toGrid.col) return;
 
 			// 成り判定: 敵陣（1段目/5段目）に入る、または敵陣内から移動する場合
@@ -874,9 +886,9 @@ export default function TatamiBackground({
 						if (capturedPiece) {
 							const capturedId = Object.keys(PIECE_INITIAL_GRID).find(pid => {
 								if (pid === id) return false;
-								const pPos = piecePositions[pid] || gridToWorld(PIECE_INITIAL_GRID[pid].row, PIECE_INITIAL_GRID[pid].col);
+								const pPos = piecePositions[pid] || gridToWorld(PIECE_INITIAL_GRID[pid].row, PIECE_INITIAL_GRID[pid].col, isFlipped);
 								if (checkIsHandPos(pPos)) return false;
-								const pg = worldToGrid(pPos[0], pPos[2]);
+								const pg = worldToGrid(pPos[0], pPos[2], isFlipped);
 								return pg && pg.row === toGrid.row && pg.col === toGrid.col;
 							});
 							if (capturedId) {
@@ -887,15 +899,15 @@ export default function TatamiBackground({
 									const coordsMap = winnerColor === Color.BLACK ? SENTE_HAND_COORDS : GOTE_HAND_COORDS;
 									const baseType = UNPROMOTE_MAP[capturedPiece.pieceType] ?? capturedPiece.pieceType;
 									const capturedHandPos = coordsMap[baseType] || [0, 0, 0];
-									return { ...prev, [capturedId]: capturedHandPos, [id]: gridToWorld(toGrid.row, toGrid.col) };
+									return { ...prev, [capturedId]: capturedHandPos, [id]: gridToWorld(toGrid.row, toGrid.col, isFlipped) };
 								});
 							} else {
 								// 駒取りがない場合でも駒を移動先に進める
-								setPiecePositions(prev => ({ ...prev, [id]: gridToWorld(toGrid.row, toGrid.col) }));
+								setPiecePositions(prev => ({ ...prev, [id]: gridToWorld(toGrid.row, toGrid.col, isFlipped) }));
 							}
 						} else {
 							// 駒がない場所への移動
-							setPiecePositions(prev => ({ ...prev, [id]: gridToWorld(toGrid.row, toGrid.col) }));
+							setPiecePositions(prev => ({ ...prev, [id]: gridToWorld(toGrid.row, toGrid.col, isFlipped) }));
 						}
 
 						// それ以外は選択
@@ -956,7 +968,7 @@ export default function TatamiBackground({
 							<group ref={boardGroupRef} position={[0, -0.9, 0]} rotation={[(Math.PI / 180) * 30, Math.PI / 2, 0]}>
 								{/* 背景クリックで選択解除用の透明な平面 */}
 								<mesh position={[0, 9.9, 0]} rotation={[-Math.PI / 2, 0, 0]} onClick={handleBackgroundClick} receiveShadow>
-									<planeGeometry args={[50, 50]} />
+									<planeGeometry args={[70, 70]} />
 									<shadowMaterial transparent opacity={0.4} />
 								</mesh>
 
@@ -964,20 +976,21 @@ export default function TatamiBackground({
 
 								{/* アシストマーク（移動可能な場所の強調） */}
 								{validMoveDestinations.map((dest, idx) => {
-									const pos = gridToWorld(dest.row, dest.col);
+									const pos = gridToWorld(dest.row, dest.col, isFlipped);
 									return <MoveMarker key={`marker-${idx}`} position={pos} />;
 								})}
 
-								{/* 駒台 (Sente: 左上) */}
+								{/* 駒台：視点に合わせて位置を入れ替える */}
+								{/* 自分の駒台 (常に右下) */}
 								<DaiModelContent
-									position={[-12.5, 0, -21]}
+									position={isFlipped ? [-21.2, 0, 12.7] : [-12.5, 0, -21]}
 									rotation={[0, Math.PI, 0]}
 									scale={[1, 1, 1]}
 								/>
 
-								{/* 駒台 (Gote: 右下) */}
+								{/* 相手の駒台 (常に左上) */}
 								<DaiModelContent
-									position={[-21.2, 0, 12.7]}
+									position={isFlipped ? [-12.5, 0, -21] : [-21.2, 0, 12.7]}
 									rotation={[0, Math.PI, 0]}
 									scale={[1, 1, 1]}
 								/>
@@ -988,7 +1001,7 @@ export default function TatamiBackground({
 										key={piece.id}
 										pieceId={piece.id}
 										modelPath={piece.model}
-										initialPosition={piecePositions[piece.id] || piece.defaultPos}
+										initialPosition={piecePositions[piece.id] || gridToWorld(PIECE_INITIAL_GRID[piece.id].row, PIECE_INITIAL_GRID[piece.id].col, isFlipped)}
 										rotation={getPieceRotation(piece.id, pieceOwners[piece.id], isPiecePromoted(piece.id))}
 										count={getHandPieceCount(piece.id)}
 										selectedId={selectedPiece}
@@ -1006,7 +1019,7 @@ export default function TatamiBackground({
 										key={piece.id}
 										pieceId={piece.id}
 										modelPath={piece.model}
-										initialPosition={piecePositions[piece.id] || piece.defaultPos}
+										initialPosition={piecePositions[piece.id] || gridToWorld(PIECE_INITIAL_GRID[piece.id].row, PIECE_INITIAL_GRID[piece.id].col, isFlipped)}
 										rotation={getPieceRotation(piece.id, pieceOwners[piece.id], isPiecePromoted(piece.id))}
 										count={getHandPieceCount(piece.id)}
 										selectedId={selectedPiece}

--- a/nextjs/hooks/useAiGame.ts
+++ b/nextjs/hooks/useAiGame.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { useGameLogic } from "./useGameLogic";
-import { boardFromPieces, type PieceInfo ,USI_TO_DROP_KANJI, Pos, PieceType, type Move } from "@torassen/shogi-logic";
+import { boardFromPieces, type PieceInfo, USI_TO_DROP_KANJI, Pos, PieceType, type Move } from "@torassen/shogi-logic";
 
 const KANJI_TO_PIECE_TYPE: Record<string, PieceType> = {
 	"歩": PieceType.PAWN,
@@ -193,12 +193,14 @@ export function useAiGame(
 	};
 
 	const handleEndMatch = () => {
-		// すでに終了している場合は何もしない
 		if (gameResult.isOver) {
+			const isWin = gameResult.winner === mySide;
+			const winParam = isWin ? "true" : "false";
+			const reasonPara = encodeURIComponent(gameResult.message || "対局終了");
+			router.push(`/result?win=${winParam}&reason=${reasonPara}`);
 			return;
 		}
 
-		// 対局中の場合は投了（負け）として扱い、内部状態を更新
 		setGameResult({
 			isOver: true,
 			winner: mySide === "sente" ? "gote" : "sente",

--- a/nextjs/hooks/useShogiGame.ts
+++ b/nextjs/hooks/useShogiGame.ts
@@ -126,7 +126,7 @@ export function useShogiGame(
 
 		const handleSyncState = (data: { sfen: string }) => {
 			const syncedBoard = sfenToUIBoard(data.sfen);
-			syncBoardState(syncedBoard); 
+			syncBoardState(syncedBoard);
 		};
 
 		socket.on("syncState", handleSyncState);
@@ -205,21 +205,18 @@ export function useShogiGame(
 			router.push("/home");
 		}
 		if (gameResult.isOver) {
-      const resultStatus = gameResult.winner === mySide ? "win" : "lose";
-
-			fetch("/api/result", {
-			method: "PUT",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ result: resultStatus }), 
-			});
-			router.push("/result" + (roomId ? `?roomId=${roomId}` : ""));
+			const isWin = gameResult.winner === mySide;
+			const winParam = isWin ? "true" : "false";
+			const reasonPara = encodeURIComponent(gameResult.message || "対局終了");
+			router.push(`/result?win=${winParam}&reason=${reasonPara}${roomId ? `&roomId=${roomId}` : ""}`);
 			return;
 		}
 		if (roomId && socket) {
+			const winner = (mySide === "sente" ? "gote" : "sente") as "sente" | "gote";
 			socket.emit("resign_match", { roomId });
 			setGameResult({
 				isOver: true,
-				winner: mySide === "sente" ? "gote" : "sente",
+				winner: winner,
 				message: "投了しました"
 			});
 		} else {


### PR DESCRIPTION
## 概要
将棋対局画面のUI/UX向上を目的に、3D盤面の視点制御ロジックの改善、対局結果アニメーションの導入、およびプレイヤー情報表示の最適化を行いました。

## 変更内容

### 1. 3D盤面の視点制御ロジックの改善
*   **「自分が常に手前」の実現**: 先手・後手に関わらず、プレイヤーの駒が常に画面下側から上側へ向かって進む視点になるよう、座標系（[gridToWorld](cci:1://file:///Users/kotasakatsume/cursur/ft_tra/nextjs/components/TatamiBackground.tsx:455:0-464:1) / [worldToGrid](cci:1://file:///Users/kotasakatsume/cursur/ft_tra/nextjs/components/TatamiBackground.tsx:466:0-494:1)）の反転ロジックを実装しました。
*   **盤面固定化**: 以前は盤モデル全体を回転させていましたが、今回は盤モデルを固定したまま駒の配置と向きだけを論理的に入れ替える方式に変更し、カメラワークの一貫性を保ちました。
*   **駒台の動的配置**: 自分の駒台が常に右下、相手の駒台が常に左上に来るよう、視点に合わせて自動的に入れ替わるようにしました。

### 2. 対局結果アニメーションの導入（Lottie）
*   **動的な演出**: 勝利時（パーティー顔 🥳）と敗北時（号泣 😭）に動的なLottieアニメーションを表示する [VictoryAnimation](cci:1://file:///Users/kotasakatsume/cursur/ft_tra/nextjs/components/VictoryAnimation.tsx:5:0-22:1) / [DefeatAnimation](cci:1://file:///Users/kotasakatsume/cursur/ft_tra/nextjs/components/DefeatAnimation.tsx:5:0-22:1) コンポーネントを作成しました。
*   **バグ修正**: 投了（resign）した際に、勝敗判定が正しく行われず「勝利」と表示されてしまうバグを修正しました。
*   **結果画面への遷移**: 対局終了後、`/result` ページへ遷移する際に勝敗フラグを正しく引き継ぐようにし、結果画面でも適切なアニメーションが表示されるようにしました。

### 3. プレイヤー情報表示の最適化
*   **配置の固定**: 「自分（あなた）」の情報は常に左下、「対戦相手（またはAI）」の情報は常に右上になるよう配置を固定しました。
*   **観戦者対応**: 観戦時には「勝利/敗北」ではなく「対局終了」と表示されるよう、オーバーレイの文言を調整しました。

## 動作確認方法
1. オンライン対局またはAI対局を開始する。
2. 後手（White）になった際、自分の駒が手前側に配置され、駒の向きが奥（相手側）を向いていることを確認。
3. 投了または終局した際、結果に応じた正しいアニメーション（勝利なら🥳、敗北なら😭）が表示されることを確認。
