### PR TITLE
Https対応＆httpアクセスをhttpsにリダイレクト

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -54,7 +54,7 @@ services:
       dockerfile: Dockerfile
     restart: unless-stopped
     ports:
-      - "8080:80"
+      - "8080:443"
     depends_on:
       - nextjs
       - ws-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       AUTH_GITHUB_SECRET: ${AUTH_GITHUB_SECRET}
       AUTH_GOOGLE_ID: ${AUTH_GOOGLE_ID}
       AUTH_GOOGLE_SECRET: ${AUTH_GOOGLE_SECRET}
-      AUTH_URL: ${AUTH_URL:-http://localhost:8080}
+      AUTH_URL: ${AUTH_URL:-https://localhost:8080}
       AUTH_TRUST_HOST: "true"
       #can access only from nginx
     depends_on:
@@ -57,7 +57,7 @@ services:
       dockerfile: Dockerfile
     restart: unless-stopped
     ports:
-      - "8080:80"
+      - "8080:443"
     depends_on:
       - nextjs
       - ws-server

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,3 +1,6 @@
 FROM nginx:alpine
+RUN apk add --no-cache openssl
+COPY generate-cert.sh /docker-entrypoint.d/generate-cert.sh
+RUN chmod +x /docker-entrypoint.d/generate-cert.sh && /docker-entrypoint.d/generate-cert.sh
 COPY nginx.conf /etc/nginx/conf.d/default.conf
-EXPOSE 80
+EXPOSE 443

--- a/nginx/generate-cert.sh
+++ b/nginx/generate-cert.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+mkdir -p /etc/nginx/ssl
+openssl req -x509 -nodes -days 365 \
+  -newkey rsa:2048 \
+  -keyout /etc/nginx/ssl/server.key \
+  -out /etc/nginx/ssl/server.crt \
+  -subj "/C=JP/ST=Tokyo/L=Tokyo/O=42Tokyo/CN=localhost"

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -6,9 +6,22 @@ upstream ws-server {
     server ws-server:3001;
 }
 
+# HTTP -> HTTPS redirect
 server {
     listen 80;
     server_name localhost;
+    return 301 https://$host$request_uri;
+}
+
+# HTTPS
+server {
+    listen 443 ssl;
+    server_name localhost;
+
+    ssl_certificate     /etc/nginx/ssl/server.crt;
+    ssl_certificate_key /etc/nginx/ssl/server.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+
     client_max_body_size 10m;    # Max request/ upload body size (e.g. avatar uploads)
     location /ws/ {
         proxy_pass http://ws-server/;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -22,6 +22,9 @@ server {
     ssl_certificate_key /etc/nginx/ssl/server.key;
     ssl_protocols       TLSv1.2 TLSv1.3;
 
+    # HTTP request to HTTPS port → redirect
+    error_page 497 https://$host:$server_port$request_uri;
+
     client_max_body_size 10m;    # Max request/ upload body size (e.g. avatar uploads)
     location /ws/ {
         proxy_pass http://ws-server/;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,3 +1,5 @@
+
+
 upstream nextjs {
     server nextjs:3000;
 }
@@ -23,7 +25,7 @@ server {
     ssl_protocols       TLSv1.2 TLSv1.3;
 
     # HTTP request to HTTPS port → redirect
-    error_page 497 https://$host:$server_port$request_uri;
+    error_page 497 https://$http_host$request_uri;
 
     client_max_body_size 10m;    # Max request/ upload body size (e.g. avatar uploads)
     location /ws/ {


### PR DESCRIPTION
# [Summary]

- httpsに全ページ対応。くいださんのレビューを踏まえてシンプルに。
- httpアクセスした時、httpsにリダイレクト
- リンクは警告でるが、サーバが正式な証明書作れないから、信頼できんぞって言われてるだけ。
- https化はしてる

<img width="1920" height="1081" alt="スクリーンショット 2026-03-29 0 13 22" src="https://github.com/user-attachments/assets/cb777587-75a8-43ae-804b-87e5d3ade8dc" />

# [Details]
httpsをしない場合、パスワードは平文で送られてセキュリティ的にまずい。

httpsをすると、例えばRSA暗号の公開鍵を最初にサーバからクライアントに１回送る。
クライアント側は公開鍵を使い暗号化し、サーバに送る。サーバは秘密鍵を使い復号。
なお最近はRSAは遅いからAESとか使うらしい