### PR TITLE
tailwindcssに移行した

### DIFF
--- a/nextjs/app/globals.css
+++ b/nextjs/app/globals.css
@@ -1,4 +1,9 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700;900&family=M+PLUS+Rounded+1c:wght@400;500;700;900&display=swap');
+
 
 :root {
   /* Wood-grain / cream palette inspired by Nintendo "World's Games" */
@@ -21,12 +26,12 @@
   --color-text-light: #7A6555;
   --color-text-muted: #A89585;
   --color-border: #E0D0C0;
-  --color-shadow: rgba(60, 40, 20, 0.12);
-  --color-shadow-strong: rgba(60, 40, 20, 0.2);
+  --color-shadow: rgba(60,40,20,0.12);
+  --color-shadow-strong: rgba(60,40,20,0.2);
   --color-piece-sente: #F5E6D0;
   --color-piece-gote: #4A4A4A;
   --color-piece-gote-bg: #E0D0C0;
-  --font-main: 'M PLUS Rounded 1c', 'Noto Sans JP', sans-serif;
+  --font-main: 'M PLUS Rounded 1c','Noto Sans JP',sans-serif;
   --radius-sm: 8px;
   --radius-md: 12px;
   --radius-lg: 16px;
@@ -49,120 +54,60 @@ html {
 }
 
 body {
-  font-family: var(--font-main);
-  background-color: var(--color-bg);
-  color: var(--color-text);
-  min-height: 100vh;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  @apply font-wafuu bg-bg text-text min-h-screen antialiased;
 }
 
 /* Page container */
 .page {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 24px;
+  @apply min-h-screen flex flex-col items-center justify-center p-6;
 }
 
 .page-top {
-  justify-content: flex-start;
-  padding-top: 48px;
+  @apply justify-start pt-12;
 }
 
 /* Logo / Title */
 .logo {
-  font-size: 2.5rem;
-  font-weight: 900;
-  color: var(--color-primary);
-  text-align: center;
-  margin-bottom: 8px;
-  letter-spacing: 0.04em;
+  @apply text-[2.5rem] font-black text-primary text-center mb-2 tracking-[0.04em];
 }
 
 .logo-sub {
-  font-size: 0.9rem;
-  color: var(--color-text-muted);
-  text-align: center;
-  margin-bottom: 32px;
+  @apply text-[0.9rem] text-text-muted text-center mb-8;
 }
 
 /* Card */
 .card {
-  background: var(--color-surface);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-md);
-  border: 2px solid var(--color-border);
-  padding: 32px;
-  width: 100%;
-  max-width: 420px;
+  @apply bg-surface rounded-lg shadow-md border-2 border-border p-8 w-full max-w-[420px];
 }
 
 .card-wide {
-  max-width: 560px;
+  @apply max-w-[560px];
 }
 
 .card-title {
-  font-size: 1.3rem;
-  font-weight: 700;
-  text-align: center;
-  margin-bottom: 24px;
-  color: var(--color-text);
+  @apply text-[1.3rem] font-bold text-center mb-6 text-text;
 }
 
 /* Form */
 .form-group {
-  margin-bottom: 16px;
+  @apply mb-4;
 }
 
 .form-label {
-  display: block;
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--color-text-light);
-  margin-bottom: 6px;
+  @apply block text-[0.85rem] font-semibold text-text-light mb-1.5;
 }
 
 .form-input {
-  width: 100%;
-  padding: 12px 16px;
-  border: 2px solid var(--color-border);
-  border-radius: var(--radius-md);
-  font-family: var(--font-main);
-  font-size: 1rem;
-  color: var(--color-text);
-  background: var(--color-bg);
-  transition: border-color 0.2s;
-  outline: none;
+  @apply w-full px-4 py-3 border-2 border-border rounded-md font-wafuu text-base text-text bg-bg transition-colors duration-200 outline-none placeholder:text-text-muted;
 }
 
 .form-input:focus {
-  border-color: var(--color-primary);
-}
-
-.form-input::placeholder {
-  color: var(--color-text-muted);
+  @apply border-primary;
 }
 
 /* Button */
 .btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 14px 28px;
-  border: 3px solid transparent;
-  border-radius: var(--radius-xl);
-  font-family: var(--font-main);
-  font-size: 1rem;
-  font-weight: 700;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  text-decoration: none;
-  user-select: none;
-  white-space: nowrap;
+  @apply inline-flex items-center justify-center gap-2 px-[28px] py-[14px] border-[3px] border-transparent rounded-xl font-wafuu text-[1rem] font-bold cursor-pointer transition-all duration-150 ease-in-out no-underline select-none whitespace-nowrap;
 }
 
 .btn:active {
@@ -176,205 +121,131 @@ body {
 }
 
 .btn-block {
-  width: 100%;
+  @apply w-full;
 }
 
 .btn-primary {
-  background: var(--color-primary);
-  color: white;
-  border-color: var(--color-primary-hover);
-  box-shadow: 0 3px 0 var(--color-primary-hover), var(--shadow-sm);
+  @apply bg-primary text-white border-primary-hover shadow-[0_3px_0_var(--color-primary-hover),var(--shadow-sm)];
 }
 
 .btn-primary:hover:not(:disabled) {
-  background: var(--color-primary-hover);
+  @apply bg-primary-hover;
 }
 
 .btn-primary:active:not(:disabled) {
-  box-shadow: 0 1px 0 var(--color-primary-hover);
-  transform: translateY(2px) scale(0.97);
+  @apply shadow-[0_1px_0_var(--color-primary-hover)] translate-y-[2px] scale-[0.97];
 }
 
 .btn-secondary {
-  background: var(--color-secondary);
-  color: white;
-  border-color: var(--color-secondary-hover);
-  box-shadow: 0 3px 0 var(--color-secondary-hover), var(--shadow-sm);
+  @apply bg-secondary text-white border-secondary-hover shadow-[0_3px_0_var(--color-secondary-hover),var(--shadow-sm)];
 }
 
 .btn-secondary:hover:not(:disabled) {
-  background: var(--color-secondary-hover);
+  @apply bg-secondary-hover;
 }
 
 .btn-secondary:active:not(:disabled) {
-  box-shadow: 0 1px 0 var(--color-secondary-hover);
-  transform: translateY(2px) scale(0.97);
+  @apply shadow-[0_1px_0_var(--color-secondary-hover)] translate-y-[2px] scale-[0.97];
 }
 
 .btn-danger {
-  background: var(--color-danger);
-  color: white;
-  border-color: var(--color-danger-hover);
-  box-shadow: 0 3px 0 var(--color-danger-hover), var(--shadow-sm);
+  @apply bg-danger text-white border-danger-hover shadow-[0_3px_0_var(--color-danger-hover),var(--shadow-sm)];
 }
 
 .btn-danger:hover:not(:disabled) {
-  background: var(--color-danger-hover);
+  @apply bg-danger-hover;
 }
 
 .btn-outline {
-  background: transparent;
-  color: var(--color-text);
-  border-color: var(--color-border);
-  box-shadow: none;
+  @apply bg-transparent text-text border-border shadow-none;
 }
 
 .btn-outline:hover:not(:disabled) {
-  background: var(--color-bg-alt);
-  border-color: var(--color-wood);
+  @apply bg-bg-alt border-wood;
 }
 
 .btn-lg {
-  padding: 18px 36px;
-  font-size: 1.15rem;
-  border-radius: var(--radius-xl);
+  @apply px-9 py-[18px] text-[1.15rem] rounded-xl;
 }
 
 .btn-sm {
-  padding: 8px 16px;
-  font-size: 0.85rem;
+  @apply px-4 py-2 text-[0.85rem];
 }
 
 /* Menu list */
 .menu-list {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  width: 100%;
+  @apply flex flex-col gap-3 w-full;
 }
 
 .menu-item {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  padding: 20px 24px;
-  background: var(--color-surface);
-  border: 2px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  cursor: pointer;
-  transition: all 0.15s ease;
-  text-decoration: none;
-  color: var(--color-text);
-  box-shadow: var(--shadow-sm);
+  @apply flex items-center gap-4 px-6 py-5 bg-surface border-2 border-border rounded-lg cursor-pointer transition-all duration-150 no-underline text-text shadow-sm;
 }
 
 .menu-item:hover {
-  border-color: var(--color-wood);
-  box-shadow: var(--shadow-md);
-  transform: translateY(-1px);
+  @apply border-wood shadow-md -translate-y-px;
 }
 
 .menu-item:active {
-  transform: translateY(0);
+  @apply translate-y-0;
 }
 
 .menu-item-icon {
-  font-size: 1.8rem;
-  flex-shrink: 0;
+  @apply text-[1.8rem] shrink-0;
 }
 
 .menu-item-content {
-  flex: 1;
+  @apply flex-1;
 }
 
 .menu-item-title {
-  font-size: 1.1rem;
-  font-weight: 700;
-  margin-bottom: 2px;
+  @apply text-[1.1rem] font-bold mb-0.5;
 }
 
 .menu-item-desc {
-  font-size: 0.8rem;
-  color: var(--color-text-muted);
+  @apply text-[0.8rem] text-text-muted;
 }
 
 .menu-item-arrow {
-  font-size: 1.2rem;
-  color: var(--color-text-muted);
+  @apply text-[1.2rem] text-text-muted;
 }
 
 /* Error box */
 .error-box {
-  background: #FEF2F2;
-  border: 2px solid #FECACA;
-  border-radius: var(--radius-md);
-  padding: 12px 16px;
-  color: var(--color-danger);
-  font-size: 0.9rem;
-  font-weight: 500;
-  margin-bottom: 16px;
+  @apply bg-[#FEF2F2] border-2 border-[#FECACA] rounded-md px-4 py-3 text-danger text-[0.9rem] font-medium mb-4;
 }
 
 /* Toggle tabs */
 .tabs {
-  display: flex;
-  border-radius: var(--radius-md);
-  overflow: hidden;
-  margin-bottom: 24px;
-  border: 2px solid var(--color-border);
+  @apply flex rounded-md overflow-hidden mb-6 border-2 border-border;
 }
 
 .tab {
-  flex: 1;
-  padding: 12px;
-  text-align: center;
-  font-weight: 700;
-  font-size: 0.95rem;
-  cursor: pointer;
-  background: var(--color-bg);
-  color: var(--color-text-light);
-  border: none;
-  font-family: var(--font-main);
-  transition: all 0.15s;
+  @apply flex-1 py-3 text-center font-bold text-[0.95rem] cursor-pointer bg-bg text-text-light border-none font-wafuu transition-all duration-150;
 }
 
 .tab-active {
-  background: var(--color-primary);
-  color: white;
+  @apply bg-primary text-white;
 }
 
 .tab:hover:not(.tab-active) {
-  background: var(--color-bg-alt);
+  @apply bg-bg-alt;
 }
 
 /* Room info */
 .room-info {
-  text-align: center;
-  padding: 24px 0;
+  @apply text-center py-6;
 }
 
 .room-id {
-  font-size: 1.8rem;
-  font-weight: 900;
-  color: var(--color-primary);
-  letter-spacing: 0.1em;
-  margin-bottom: 8px;
+  @apply text-[1.8rem] font-black text-primary tracking-[0.1em] mb-2;
 }
 
 .room-status {
-  font-size: 1rem;
-  color: var(--color-text-light);
-  margin-bottom: 24px;
+  @apply text-base text-text-light mb-6;
 }
 
 .room-status-dot {
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: var(--color-success);
-  margin-right: 8px;
-  animation: pulse 1.5s ease-in-out infinite;
+  @apply inline-block w-[10px] h-[10px] rounded-full bg-success mr-2 animate-pulse;
 }
 
 @keyframes pulse {
@@ -390,214 +261,127 @@ body {
 }
 
 .copy-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 16px;
-  background: var(--color-bg-alt);
-  border: 2px solid var(--color-border);
-  border-radius: var(--radius-md);
-  font-family: var(--font-main);
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--color-text-light);
-  cursor: pointer;
-  transition: all 0.15s;
-  margin-bottom: 24px;
+  @apply inline-flex items-center gap-1.5 px-4 py-2 bg-bg-alt border-2 border-border rounded-md font-wafuu text-[0.85rem] font-semibold text-text-light cursor-pointer transition-all duration-150 mb-6;
 }
 
 .copy-btn:hover {
-  border-color: var(--color-wood);
-  background: var(--color-wood-light);
+  @apply border-wood bg-wood-light;
 }
 
 /* Shogi Board */
 .board-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 16px;
-  padding: 24px;
+  @apply flex flex-col items-center gap-4 p-6;
 }
 
 .board-player-info {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 8px 20px;
-  background: var(--color-surface);
-  border-radius: var(--radius-md);
-  border: 2px solid var(--color-border);
-  font-weight: 600;
-  font-size: 0.95rem;
+  @apply flex items-center gap-3 px-5 py-2 bg-surface rounded-md border-2 border-border font-semibold text-[0.95rem];
 }
 
 .board-player-badge {
-  padding: 2px 10px;
-  border-radius: var(--radius-sm);
-  font-size: 0.75rem;
-  font-weight: 700;
+  @apply px-2.5 py-0.5 rounded-sm text-[0.75rem] font-bold;
 }
 
 .badge-sente {
-  background: var(--color-primary);
-  color: white;
+  @apply bg-primary text-white;
 }
 
 .badge-gote {
-  background: #6495ed;
-  color: white;
+  @apply bg-[#6495ed] text-white;
 }
 
 .board {
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  grid-template-rows: repeat(5, 1fr);
-  gap: 2px;
-  background: transparent;
-  padding: 3px;
-  border-radius: var(--radius-md);
-  border: 3px solid transparent;
-  box-shadow: none;
-  width: 100%;
-  max-width: 350px;
-  aspect-ratio: 1;
+  @apply grid grid-cols-5 grid-rows-5 gap-[2px] bg-transparent p-[3px] rounded-md border-[3px] border-transparent shadow-none w-full max-w-[350px] aspect-square;
 }
 
 .board-cell {
-  background: transparent;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  position: relative;
-  cursor: pointer;
-  transition: background 0.1s;
+  @apply bg-transparent flex items-center justify-center relative cursor-pointer transition-colors duration-100;
 }
 
 .board-cell:hover {
-  background: rgba(255, 255, 255, 0.1);
+  @apply bg-white/10;
 }
 
 .piece {
-  width: 80%;
-  height: 80%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: clamp(1rem, 4vw, 1.6rem);
-  font-weight: 900;
-  position: relative;
+  @apply w-4/5 h-4/5 flex items-center justify-center text-[clamp(1rem,4vw,1.6rem)] font-black relative;
 }
 
 .piece-sente {
-  color: var(--color-text);
+  @apply text-text;
 }
 
 .piece-gote {
-  color: var(--color-piece-gote);
-  transform: rotate(180deg);
+  @apply text-piece-gote rotate-180;
 }
 
 .piece-inner {
-  width: 100%;
-  height: 100%;
-  background: var(--color-piece-sente);
-  clip-path: polygon(50% 5%, 95% 25%, 95% 95%, 5% 95%, 5% 25%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 2px solid var(--color-wood-dark);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+  @apply w-full h-full bg-piece-sente [clip-path:polygon(50%_5%,95%_25%,95%_95%,5%_95%,5%_25%)] flex items-center justify-center border-2 border-wood-dark shadow-[0_1px_3px_rgba(0,0,0,0.15)];
 }
 
 .piece-gote .piece-inner {
-  background: var(--color-piece-gote-bg);
+  @apply bg-piece-gote-bg;
 }
 
 /* Result page */
 .result-container {
-  text-align: center;
+  @apply text-center;
 }
 
 .result-title {
-  font-size: 2rem;
-  font-weight: 900;
-  margin-bottom: 8px;
+  @apply text-[2rem] font-black mb-2;
 }
 
 .result-win {
-  color: var(--color-primary);
+  @apply text-primary;
 }
 
 .result-lose {
-  color: var(--color-secondary);
+  @apply text-secondary;
 }
 
 .result-reason {
-  font-size: 0.95rem;
-  color: var(--color-text-muted);
-  margin-bottom: 32px;
+  @apply text-[0.95rem] text-text-muted mb-8;
 }
 
 .result-buttons {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  width: 100%;
-  max-width: 300px;
-  margin: 0 auto;
+  @apply flex flex-col gap-3 w-full max-w-[300px] mx-auto;
 }
 
 /* Header bar */
 .header {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 16px 24px;
-  background: var(--color-surface);
-  border-bottom: 2px solid var(--color-border);
-  position: sticky;
-  top: 0;
-  z-index: 100;
+  @apply w-full flex items-center justify-between px-6 py-4 bg-surface border-b-2 border-border sticky top-0 z-[100];
 }
 
 .header-logo {
-  font-size: 1.3rem;
-  font-weight: 900;
-  color: var(--color-primary);
+  @apply text-[1.3rem] font-black text-primary;
 }
 
 .header-user {
-  display: flex;
-  align-items: center;
-  gap: 12px;
+  @apply flex items-center gap-3;
 }
 
 .header-username {
-  font-weight: 600;
-  font-size: 0.9rem;
+  @apply font-semibold text-[0.9rem];
 }
 
 /* Spacing helpers */
 .mt-16 {
-  margin-top: 16px;
+  @apply mt-4;
 }
 
 .mt-24 {
-  margin-top: 24px;
+  @apply mt-6;
 }
 
 .mb-8 {
-  margin-bottom: 8px;
+  @apply mb-2;
 }
 
 .mb-16 {
-  margin-bottom: 16px;
+  @apply mb-4;
 }
 
 .mb-24 {
-  margin-bottom: 24px;
+  @apply mb-6;
 }
 
 .text-center {
@@ -605,11 +389,11 @@ body {
 }
 
 .text-muted {
-  color: var(--color-text-muted);
+  @apply text-text-muted;
 }
 
 .text-sm {
-  font-size: 0.85rem;
+  @apply text-[0.85rem];
 }
 
 /* Responsive */
@@ -639,68 +423,45 @@ body {
 /* Board cell selected state */
 .board-cell-selected {
   background: #FFD700 !important;
-  box-shadow: inset 0 0 8px rgba(255, 193, 7, 0.6);
+  box-shadow: inset 0 0 8px rgba(255,193,7,0.6);
 }
 
 /* WS connection status */
 .ws-status {
-  display: inline-flex;
-  align-items: center;
-  padding: 4px 12px;
-  border-radius: var(--radius-sm);
-  font-size: 0.75rem;
-  font-weight: 700;
-  white-space: nowrap;
+  @apply inline-flex items-center px-3 py-1 rounded-sm text-[0.75rem] font-bold whitespace-nowrap;
 }
 
 .ws-status-connected {
-  background: #E8F5E9;
-  color: #2E7D32;
-  border: 1px solid #A5D6A7;
+  @apply bg-[#E8F5E9] text-[#2E7D32] border border-[#A5D6A7];
 }
 
 .ws-status-disconnected {
-  background: #FFEBEE;
-  color: #C62828;
-  border: 1px solid #EF9A9A;
+  @apply bg-[#FFEBEE] text-[#C62828] border border-[#EF9A9A];
 }
 
 .ws-status-connecting {
-  background: #FFF8E1;
-  color: #F57F17;
-  border: 1px solid #FFE082;
-  animation: pulse 1.5s ease-in-out infinite;
+  @apply bg-[#FFF8E1] text-[#F57F17] border border-[#FFE082] animate-pulse;
 }
 
 /* Turn indicator */
 .turn-indicator {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 8px;
+  @apply flex items-center gap-2 mb-2;
 }
 
 .turn-badge {
-  padding: 6px 16px;
-  border-radius: var(--radius-md);
-  font-size: 1rem;
-  font-weight: 700;
+  @apply px-4 py-1.5 rounded-md text-base font-bold;
 }
 
 .turn-sente {
-  background: var(--color-primary);
-  color: white;
+  @apply bg-primary text-white;
 }
 
 .turn-gote {
-  background: var(--color-text);
-  color: white;
+  @apply bg-text text-white;
 }
 
 .turn-you {
-  font-size: 0.85rem;
-  color: var(--color-text-muted);
-  font-weight: 500;
+  @apply text-[0.85rem] text-text-muted font-medium;
 }
 
 /* ===== Legal move highlights ===== */
@@ -709,14 +470,7 @@ body {
 }
 
 .legal-dot {
-  position: absolute;
-  width: 28%;
-  height: 28%;
-  border-radius: 50%;
-  background: rgba(76, 175, 80, 0.55);
-  z-index: 5;
-  pointer-events: none;
-  animation: legalPulse 1.2s ease-in-out infinite;
+  @apply absolute w-[28%] h-[28%] rounded-full bg-green-500/55 z-[5] pointer-events-none animate-[legalPulse_1.2s_ease-in-out_infinite];
 }
 
 @keyframes legalPulse {
@@ -734,54 +488,32 @@ body {
 }
 
 .board-cell-capture {
-  background: rgba(229, 115, 115, 0.35) !important;
-  box-shadow: inset 0 0 6px rgba(229, 115, 115, 0.5);
+  @apply !bg-red-400/35 shadow-[inset_0_0_6px_rgba(229,115,115,0.5)];
 }
 
 /* ===== Hand (持ち駒) area ===== */
 .hand-area {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-left: auto;
-  flex-wrap: wrap;
+  @apply flex items-center gap-1.5 ml-auto flex-wrap;
 }
 
 .hand-empty {
-  font-size: 0.8rem;
-  color: var(--color-text-muted);
-  margin-left: auto;
+  @apply text-[0.8rem] text-text-muted ml-auto;
 }
 
 .hand-piece {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 40px;
-  border: 2px solid var(--color-wood-dark);
-  border-radius: var(--radius-sm);
-  background: var(--color-piece-sente);
-  cursor: pointer;
-  transition: all 0.15s ease;
-  font-family: var(--font-main);
-  padding: 0;
+  @apply relative inline-flex items-center justify-center w-9 h-10 border-2 border-wood-dark rounded-sm bg-piece-sente cursor-pointer transition-all duration-150 font-wafuu p-0;
 }
 
 .hand-piece:disabled {
-  cursor: default;
-  opacity: 0.7;
+  @apply cursor-default opacity-70;
 }
 
 .hand-piece:not(:disabled):hover {
-  border-color: var(--color-primary);
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-sm);
+  @apply border-primary -translate-y-[2px] shadow-sm;
 }
 
 .hand-piece-gote {
-  background: var(--color-piece-gote-bg);
+  @apply bg-piece-gote-bg;
 }
 
 .hand-piece-gote .hand-piece-kanji {
@@ -789,33 +521,15 @@ body {
 }
 
 .hand-piece-selected {
-  border-color: var(--color-primary) !important;
-  box-shadow: 0 0 0 3px rgba(232, 131, 74, 0.35), var(--shadow-md) !important;
-  background: #FFE8D0 !important;
-  transform: translateY(-3px) !important;
+  @apply !border-primary !shadow-[0_0_0_3px_rgba(232,131,74,0.35),var(--shadow-md)] !bg-[#FFE8D0] !-translate-y-[3px];
 }
 
 .hand-piece-kanji {
-  font-size: 1rem;
-  font-weight: 900;
-  color: var(--color-text);
+  @apply text-base font-black text-text;
 }
 
 .hand-piece-count {
-  position: absolute;
-  bottom: -4px;
-  right: -4px;
-  background: var(--color-primary);
-  color: white;
-  font-size: 0.6rem;
-  font-weight: 700;
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  line-height: 1;
+  @apply absolute -bottom-1 -right-1 bg-primary text-white text-[0.6rem] font-bold w-4 h-4 rounded-full flex items-center justify-center leading-none;
 }
 
 /* ===== Promoted piece (成り駒) ===== */
@@ -825,15 +539,7 @@ body {
 
 /* ===== Promotion dialog ===== */
 .promote-overlay {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(0, 0, 0, 0.45);
-  z-index: 1000;
-  backdrop-filter: blur(3px);
-  animation: fadeIn 0.15s ease;
+  @apply fixed inset-0 flex items-center justify-center bg-black/45 z-[1000] backdrop-blur-[3px] animate-[fadeIn_0.15s_ease];
 }
 
 @keyframes fadeIn {
@@ -847,13 +553,7 @@ body {
 }
 
 .promote-dialog {
-  background: var(--color-surface);
-  border-radius: var(--radius-lg);
-  border: 3px solid var(--color-wood-dark);
-  padding: 28px 36px;
-  box-shadow: var(--shadow-lg);
-  text-align: center;
-  animation: scaleIn 0.2s ease;
+  @apply bg-surface rounded-lg border-[3px] border-wood-dark p-[28px_36px] shadow-lg text-center animate-[scaleIn_0.2s_ease];
 }
 
 @keyframes scaleIn {
@@ -869,16 +569,11 @@ body {
 }
 
 .promote-title {
-  font-size: 1.2rem;
-  font-weight: 700;
-  margin-bottom: 20px;
-  color: var(--color-text);
+  @apply text-[1.2rem] font-bold mb-5 text-text;
 }
 
 .promote-buttons {
-  display: flex;
-  gap: 12px;
-  justify-content: center;
+  @apply flex gap-3 justify-center;
 }
 
 .promote-btn {
@@ -892,7 +587,7 @@ body {
   background: var(--color-primary) !important;
   color: white !important;
   border-color: var(--color-primary-hover) !important;
-  box-shadow: 0 3px 0 var(--color-primary-hover), var(--shadow-sm) !important;
+  box-shadow: 0 3px 0 var(--color-primary-hover),var(--shadow-sm) !important;
 }
 
 .promote-btn-yes:hover {
@@ -903,7 +598,7 @@ body {
   background: var(--color-bg-alt) !important;
   color: var(--color-text) !important;
   border-color: var(--color-border) !important;
-  box-shadow: 0 3px 0 #d0c0a8, var(--shadow-sm) !important;
+  box-shadow: 0 3px 0 #d0c0a8,var(--shadow-sm) !important;
 }
 
 .promote-btn-no:hover {
@@ -912,25 +607,12 @@ body {
 
 /* ===== Board player info extended with hand area ===== */
 .board-player-info {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 8px 20px;
-  background: var(--color-surface);
-  border-radius: var(--radius-md);
-  border: 2px solid var(--color-border);
-  font-weight: 600;
-  font-size: 0.95rem;
-  min-width: 350px;
+  @apply flex items-center gap-3 px-5 py-2 bg-surface rounded-md border-2 border-border font-semibold text-[0.95rem] min-w-[350px];
 }
 
 /* ===== AI Match ===== */
 .ai-thinking {
-  display: inline-block;
-  margin-left: 12px;
-  font-size: 0.9rem;
-  color: var(--color-primary);
-  animation: pulse-thinking 1.2s ease-in-out infinite;
+  @apply inline-block ml-3 text-[0.9rem] text-primary animate-[pulse-thinking_1.2s_ease-in-out_infinite];
 }
 
 @keyframes pulse-thinking {
@@ -946,9 +628,5 @@ body {
 }
 
 .game-over-label {
-  display: inline-block;
-  margin-left: 12px;
-  font-size: 0.95rem;
-  font-weight: 700;
-  color: #e74c3c;
+  @apply inline-block ml-3 text-[0.95rem] font-bold text-[#e74c3c];
 }

--- a/nextjs/app/login/login.css
+++ b/nextjs/app/login/login.css
@@ -1,278 +1,139 @@
 /* ===============================
-   Login Page — 和風テーマ
+   Login Page — Tailwind移行版
    =============================== */
 
 .login-page {
-    position: relative;
-    min-height: 100vh;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    overflow: hidden;
+    @apply relative min-h-screen flex items-center justify-center overflow-hidden;
 }
 
 /* --- 背景画像 --- */
 .login-bg {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 0;
-    background-image: url("/images/login-bg.png");
-    background-size: cover;
-    background-position: center;
-    background-repeat: no-repeat;
+    @apply fixed top-0 left-0 w-full h-full z-0 bg-[url("/images/login-bg.png")] bg-cover bg-center bg-no-repeat;
 }
 
 /* --- 暗いオーバーレイ --- */
 .login-bg::after {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: linear-gradient(180deg,
-            rgba(10, 10, 20, 0.4) 0%,
-            rgba(10, 10, 20, 0.7) 100%);
+    @apply content-[""] absolute top-0 left-0 w-full h-full bg-gradient-to-b from-[rgba(10,10,20,0.4)] to-[rgba(10,10,20,0.7)];
 }
 
 /* --- コンテンツ --- */
 .login-content {
-    position: relative;
-    z-index: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 24px;
-    width: 100%;
-    max-width: 420px;
-    padding: 0 20px;
+    @apply relative z-[1] flex flex-col items-center gap-6 w-full max-w-[420px] px-5;
 }
 
 /* --- タイトル --- */
 .login-title {
-    text-align: center;
-    color: #f5e6c8;
-    font-size: 2.4rem;
-    font-weight: 800;
-    letter-spacing: 0.15em;
-    text-shadow:
-        0 0 20px rgba(212, 175, 55, 0.5),
-        0 2px 8px rgba(0, 0, 0, 0.8);
-    margin: 0;
+    @apply text-center text-[#f5e6c8] text-[2.4rem] font-extrabold tracking-widest [text-shadow:0_0_20px_rgba(212,175,55,0.5),0_2px_8px_rgba(0,0,0,0.8)] m-0;
 }
 
 .login-subtitle {
-    color: rgba(245, 230, 200, 0.6);
-    font-size: 0.85rem;
-    letter-spacing: 0.3em;
-    margin-top: -8px;
+    @apply text-[rgba(245,230,200,0.6)] text-[0.85rem] tracking-[0.3em] -mt-2;
 }
 
 /* --- カード --- */
 .login-card {
-    width: 100%;
-    background: rgba(20, 15, 10, 0.85);
-    backdrop-filter: blur(16px);
-    border: 1px solid rgba(212, 175, 55, 0.15);
-    border-radius: 16px;
-    padding: 32px 28px;
-    box-shadow:
-        0 8px 32px rgba(0, 0, 0, 0.6),
-        inset 0 1px 0 rgba(212, 175, 55, 0.1);
+    @apply w-full bg-[rgba(20,15,10,0.85)] backdrop-blur-2xl border border-[rgba(212,175,55,0.15)] rounded-2xl p-[32px_28px] shadow-[0_8px_32px_rgba(0,0,0,0.6),inset_0_1px_0_rgba(212,175,55,0.1)];
 }
 
 /* --- タブ --- */
 .login-tabs {
-    display: flex;
-    gap: 0;
-    margin-bottom: 24px;
-    border-radius: 10px;
-    overflow: hidden;
-    border: 1px solid rgba(212, 175, 55, 0.2);
+    @apply flex gap-0 mb-6 rounded-[10px] overflow-hidden border border-[rgba(212,175,55,0.2)];
 }
 
 .login-tab {
-    flex: 1;
-    padding: 10px 0;
-    border: none;
-    background: transparent;
-    color: rgba(245, 230, 200, 0.5);
-    font-size: 0.9rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    letter-spacing: 0.05em;
+    @apply flex-1 py-2.5 border-none bg-transparent text-[rgba(245,230,200,0.5)] text-[0.9rem] font-semibold cursor-pointer transition-all duration-300 tracking-wider;
 }
 
 .login-tab:hover {
-    color: rgba(245, 230, 200, 0.8);
-    background: rgba(212, 175, 55, 0.05);
+    @apply text-[rgba(245,230,200,0.8)] bg-[rgba(212,175,55,0.05)];
 }
 
 .login-tab-active {
-    background: rgba(212, 175, 55, 0.15);
-    color: #f5e6c8;
+    @apply bg-[rgba(212,175,55,0.15)] text-[#f5e6c8];
 }
 
 /* --- フォーム --- */
 .login-form {
-    display: flex;
-    flex-direction: column;
-    gap: 18px;
+    @apply flex flex-col gap-[18px];
 }
 
 .login-field {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
+    @apply flex flex-col gap-1.5;
 }
 
 .login-label {
-    font-size: 0.8rem;
-    color: rgba(245, 230, 200, 0.6);
-    font-weight: 500;
-    letter-spacing: 0.05em;
+    @apply text-[0.8rem] text-[rgba(245,230,200,0.6)] font-medium tracking-wider;
 }
 
 .login-input {
-    padding: 12px 14px;
-    background: rgba(245, 230, 200, 0.06);
-    border: 1px solid rgba(212, 175, 55, 0.15);
-    border-radius: 10px;
-    color: #f5e6c8;
-    font-size: 0.95rem;
-    outline: none;
-    transition: all 0.3s ease;
+    @apply p-[12px_14px] bg-[rgba(245,230,200,0.06)] border border-[rgba(212,175,55,0.15)] rounded-xl text-[#f5e6c8] text-[0.95rem] outline-none transition-all duration-300;
 }
 
 .login-input::placeholder {
-    color: rgba(245, 230, 200, 0.25);
+    @apply text-[rgba(245,230,200,0.25)];
 }
 
 .login-input:focus {
-    border-color: rgba(212, 175, 55, 0.5);
-    background: rgba(245, 230, 200, 0.1);
-    box-shadow: 0 0 12px rgba(212, 175, 55, 0.1);
+    @apply border-[rgba(212,175,55,0.5)] bg-[rgba(245,230,200,0.1)] shadow-[0_0_12px_rgba(212,175,55,0.1)];
 }
 
 /* --- エラー --- */
 .login-error {
-    background: rgba(200, 50, 50, 0.15);
-    border: 1px solid rgba(200, 50, 50, 0.3);
-    border-radius: 10px;
-    padding: 10px 14px;
-    color: #ff8888;
-    font-size: 0.85rem;
-    margin-bottom: 4px;
+    @apply bg-[rgba(200,50,50,0.15)] border border-[rgba(200,50,50,0.3)] rounded-xl p-[10px_14px] text-[#ff8888] text-[0.85rem] mb-1;
 }
 
 /* --- ボタン --- */
 .login-btn {
-    margin-top: 8px;
-    padding: 14px 0;
-    border: none;
-    border-radius: 10px;
-    background: linear-gradient(135deg, #b8860b 0%, #d4af37 50%, #b8860b 100%);
-    color: #1a1208;
-    font-size: 1rem;
-    font-weight: 700;
-    letter-spacing: 0.1em;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 16px rgba(212, 175, 55, 0.3);
+    @apply mt-2 py-3.5 border-none rounded-xl bg-gradient-to-br from-[#b8860b] via-[#d4af37] to-[#b8860b] text-[#1a1208] text-base font-bold tracking-widest cursor-pointer transition-all duration-300 shadow-[0_4px_16px_rgba(212,175,55,0.3)];
 }
 
 .login-btn:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 6px 24px rgba(212, 175, 55, 0.4);
-    background: linear-gradient(135deg, #d4af37 0%, #f0d060 50%, #d4af37 100%);
+    @apply -translate-y-px shadow-[0_6px_24px_rgba(212,175,55,0.4)] bg-gradient-to-br from-[#d4af37] via-[#f0d060] to-[#d4af37];
 }
 
 .login-btn:active {
-    transform: translateY(0);
+    @apply translate-y-0;
 }
 
 .login-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-    transform: none;
-}
-
-/* --- レスポンシブ --- */
-@media (max-width: 480px) {
-    .login-content {
-        padding: 0 16px;
-    }
-
-    .login-card {
-        padding: 24px 20px;
-    }
-
-    .login-title {
-        font-size: 1.8rem;
-    }
+    @apply opacity-50 cursor-not-allowed translate-y-0;
 }
 
 /* --- OAuth セパレーター --- */
 .oauth-separator {
-    display: flex;
-    align-items: center;
-    margin: 24px 0;
-    color: rgba(245, 230, 200, 0.3);
-    font-size: 0.8rem;
+    @apply flex items-center my-6 text-[rgba(245,230,200,0.3)] text-[0.8rem];
 }
 
 .oauth-separator::before,
 .oauth-separator::after {
-    content: "";
-    flex: 1;
-    height: 1px;
-    background: rgba(212, 175, 55, 0.15);
+    @apply content-[""] flex-1 h-[1px] bg-[rgba(212,175,55,0.15)];
 }
 
 .oauth-separator span {
-    padding: 0 12px;
+    @apply px-3;
 }
 
 /* --- OAuth ボタン --- */
 .oauth-buttons {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
+    @apply flex flex-col gap-3;
 }
 
 .oauth-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 12px;
-    border-radius: 10px;
-    font-size: 0.9rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    border: 1px solid rgba(212, 175, 55, 0.2);
+    @apply flex items-center justify-center p-3 rounded-xl text-[0.9rem] font-semibold cursor-pointer transition-all duration-300 border border-[rgba(212,175,55,0.2)];
 }
 
 .github-btn {
-    background: #24292e;
-    color: #ffffff;
+    @apply bg-[#24292e] text-white;
 }
 
 .github-btn:hover {
-    background: #33393f;
-    border-color: rgba(212, 175, 55, 0.4);
+    @apply bg-[#33393f] border-[rgba(212,175,55,0.4)];
 }
 
 .google-btn {
-    background: #ffffff;
-    color: #1a1a1a;
+    @apply bg-white text-[#1a1a1a];
 }
 
 .google-btn:hover {
-    background: #f1f1f1;
-    border-color: rgba(212, 175, 55, 0.4);
+    @apply bg-[#f1f1f1] border-[rgba(212,175,55,0.4)];
 }

--- a/nextjs/app/wafuu-theme.css
+++ b/nextjs/app/wafuu-theme.css
@@ -1,391 +1,204 @@
 /* ===============================
-   和風テーマ — 共通スタイル
+   和風テーマ — Tailwind移行版
    =============================== */
 
 /* --- 和風ページ共通レイアウト --- */
 .wafuu-page {
-	position: relative;
-	min-height: 100vh;
-	display: flex;
-	flex-direction: column;
-	overflow: hidden;
+	@apply relative min-h-screen flex flex-col overflow-hidden;
 }
 
 /* --- 背景 --- */
 .wafuu-bg {
-	position: fixed;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
-	z-index: 0;
-	background-size: cover;
-	background-position: center;
-	background-repeat: no-repeat;
+	@apply fixed top-0 left-0 w-full h-full z-0 bg-cover bg-center bg-no-repeat;
 }
 
 .wafuu-bg::after {
-	content: "";
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
-	background: linear-gradient(180deg,
-			rgba(10, 10, 20, 0.3) 0%,
-			rgba(10, 10, 20, 0.65) 100%);
+	@apply content-[""] absolute top-0 left-0 w-full h-full bg-gradient-to-b from-[rgba(10,10,20,0.3)] to-[rgba(10,10,20,0.65)];
 }
 
 /* --- ヘッダー --- */
 .wafuu-header {
-	position: fixed;
-	top: 0;
-	left: 0;
-	right: 0;
-	z-index: 10;
-	pointer-events: auto;
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	padding: 16px 24px;
-	background: rgba(10, 8, 5, 0.6);
-	backdrop-filter: blur(12px);
-	border-bottom: 1px solid rgba(212, 175, 55, 0.15);
+	@apply fixed top-0 left-0 right-0 z-10 pointer-events-auto flex items-center justify-between px-6 py-4 bg-[rgba(10,8,5,0.6)] backdrop-blur-xl border-b border-[rgba(212,175,55,0.15)];
 }
 
 .wafuu-header-logo {
-	color: #f5e6c8;
-	font-size: 1.2rem;
-	font-weight: 700;
-	letter-spacing: 0.08em;
-	text-decoration: none;
-	text-shadow: 0 0 12px rgba(212, 175, 55, 0.4);
+	@apply text-[#f5e6c8] text-[1.2rem] font-bold tracking-widest no-underline [text-shadow:0_0_12px_rgba(212,175,55,0.4)];
 }
 
 .wafuu-header-right {
-	display: flex;
-	align-items: center;
-	gap: 12px;
+	@apply flex items-center gap-3;
 }
 
 .wafuu-header-username {
-	color: rgba(245, 230, 200, 0.7);
-	font-size: 0.85rem;
+	@apply text-[rgba(245,230,200,0.7)] text-[0.85rem];
 }
 
 .wafuu-header-btn {
-	padding: 6px 14px;
-	border: 1px solid rgba(212, 175, 55, 0.3);
-	border-radius: 8px;
-	background: transparent;
-	color: rgba(245, 230, 200, 0.7);
-	font-size: 0.8rem;
-	cursor: pointer;
-	transition: all 0.3s ease;
+	@apply px-3.5 py-1.5 border border-[rgba(212,175,55,0.3)] rounded-lg bg-transparent text-[rgba(245,230,200,0.7)] text-[0.8rem] cursor-pointer transition-all duration-300;
 }
 
 .wafuu-header-btn:hover {
-	background: rgba(212, 175, 55, 0.1);
-	color: #f5e6c8;
-	border-color: rgba(212, 175, 55, 0.5);
+	@apply bg-[rgba(212,175,55,0.1)] text-[#f5e6c8] border-[rgba(212,175,55,0.5)];
 }
 
 /* --- コンテンツ --- */
 .wafuu-content {
-	position: relative;
-	z-index: 1;
-	flex: 1;
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	padding: 32px 20px;
+	@apply relative z-[1] flex-1 flex flex-col items-center justify-center px-5 py-8;
 }
 
 /* --- 見出し --- */
 .wafuu-heading {
-	color: #f5e6c8;
-	font-size: 1.6rem;
-	font-weight: 700;
-	letter-spacing: 0.1em;
-	text-shadow: 0 2px 8px rgba(0, 0, 0, 0.8);
-	margin: 0 0 24px;
-	text-align: center;
+	@apply text-[#f5e6c8] text-[1.6rem] font-bold tracking-widest [text-shadow:0_2px_8px_rgba(0,0,0,0.8)] mb-6 text-center;
 }
 
 .wafuu-subheading {
-	color: rgba(245, 230, 200, 0.5);
-	font-size: 0.85rem;
-	letter-spacing: 0.2em;
-	margin-top: -16px;
-	margin-bottom: 24px;
-	text-align: center;
+	@apply text-[rgba(245,230,200,0.5)] text-[0.85rem] tracking-[0.2em] -mt-4 mb-6 text-center;
 }
 
 /* --- カード --- */
 .wafuu-card {
-	width: 100%;
-	max-width: 440px;
-	background: rgba(20, 15, 10, 0.85);
-	backdrop-filter: blur(16px);
-	border: 1px solid rgba(212, 175, 55, 0.15);
-	border-radius: 16px;
-	padding: 28px 24px;
-	box-shadow:
-		0 8px 32px rgba(0, 0, 0, 0.5),
-		inset 0 1px 0 rgba(212, 175, 55, 0.1);
+	@apply w-full max-w-[440px] bg-[rgba(20,15,10,0.85)] backdrop-blur-2xl border border-[rgba(212,175,55,0.15)] rounded-2xl p-[28px_24px] shadow-[0_8px_32px_rgba(0,0,0,0.5),inset_0_1px_0_rgba(212,175,55,0.1)];
 }
 
 /* --- メニューアイテム --- */
 .wafuu-menu {
-	display: flex;
-	flex-direction: column;
-	gap: 12px;
-	width: 100%;
-	max-width: 440px;
+	@apply flex flex-col gap-3 w-full max-w-[440px];
 }
 
 .wafuu-menu-item {
-	display: flex;
-	align-items: center;
-	gap: 16px;
-	padding: 18px 20px;
-	background: rgba(20, 15, 10, 0.8);
-	backdrop-filter: blur(12px);
-	border: 1px solid rgba(212, 175, 55, 0.12);
-	border-radius: 14px;
-	text-decoration: none;
-	cursor: pointer;
-	transition: all 0.3s ease;
+	@apply flex items-center gap-4 p-[18px_20px] bg-[rgba(20,15,10,0.8)] backdrop-blur-xl border border-[rgba(212,175,55,0.12)] rounded-[14px] no-underline cursor-pointer transition-all duration-300;
 }
 
 .wafuu-menu-item:hover {
-	background: rgba(212, 175, 55, 0.1);
-	border-color: rgba(212, 175, 55, 0.35);
-	transform: translateX(4px);
+	@apply bg-[rgba(212,175,55,0.1)] border-[rgba(212,175,55,0.35)] translate-x-1;
 }
 
 .wafuu-menu-icon {
-	font-size: 1.5rem;
-	width: 40px;
-	text-align: center;
-	flex-shrink: 0;
+	@apply text-[1.5rem] w-10 text-center shrink-0;
 }
 
 .wafuu-menu-text {
-	flex: 1;
+	@apply flex-1;
 }
 
 .wafuu-menu-title {
-	color: #f5e6c8;
-	font-size: 1rem;
-	font-weight: 600;
+	@apply text-[#f5e6c8] text-base font-semibold;
 }
 
 .wafuu-menu-desc {
-	color: rgba(245, 230, 200, 0.45);
-	font-size: 0.8rem;
-	margin-top: 2px;
+	@apply text-[rgba(245,230,200,0.45)] text-[0.8rem] mt-0.5;
 }
 
 .wafuu-menu-arrow {
-	color: rgba(212, 175, 55, 0.4);
-	font-size: 1.2rem;
-	transition: all 0.3s ease;
+	@apply text-[rgba(212,175,55,0.4)] text-[1.2rem] transition-all duration-300;
 }
 
 .wafuu-menu-item:hover .wafuu-menu-arrow {
-	color: rgba(212, 175, 55, 0.8);
-	transform: translateX(4px);
+	@apply text-[rgba(212,175,55,0.8)] translate-x-1;
 }
 
 /* --- ボタン --- */
 .wafuu-btn-primary {
-	width: 100%;
-	padding: 14px 0;
-	border: none;
-	border-radius: 10px;
-	background: linear-gradient(135deg, #b8860b 0%, #d4af37 50%, #b8860b 100%);
-	color: #1a1208;
-	font-size: 1rem;
-	font-weight: 700;
-	letter-spacing: 0.1em;
-	cursor: pointer;
-	transition: all 0.3s ease;
-	box-shadow: 0 4px 16px rgba(212, 175, 55, 0.3);
+	@apply w-full py-3.5 border-none rounded-xl bg-gradient-to-br from-[#b8860b] via-[#d4af37] to-[#b8860b] text-[#1a1208] text-base font-bold tracking-widest cursor-pointer transition-all duration-300 shadow-[0_4px_16px_rgba(212,175,55,0.3)];
 }
 
 .wafuu-btn-primary:hover {
-	transform: translateY(-1px);
-	box-shadow: 0 6px 24px rgba(212, 175, 55, 0.4);
-	background: linear-gradient(135deg, #d4af37 0%, #f0d060 50%, #d4af37 100%);
+	@apply -translate-y-px shadow-[0_6px_24px_rgba(212,175,55,0.4)] bg-gradient-to-br from-[#d4af37] via-[#f0d060] to-[#d4af37];
 }
 
 .wafuu-btn-primary:disabled {
-	opacity: 0.5;
-	cursor: not-allowed;
-	transform: none;
+	@apply opacity-50 cursor-not-allowed translate-y-0;
 }
 
 .wafuu-btn-secondary {
-	width: 100%;
-	padding: 14px 0;
-	border: 1px solid rgba(212, 175, 55, 0.3);
-	border-radius: 10px;
-	background: rgba(212, 175, 55, 0.08);
-	color: #f5e6c8;
-	font-size: 1rem;
-	font-weight: 600;
-	letter-spacing: 0.08em;
-	cursor: pointer;
-	transition: all 0.3s ease;
+	@apply w-full py-3.5 border border-[rgba(212,175,55,0.3)] rounded-xl bg-[rgba(212,175,55,0.08)] text-[#f5e6c8] text-base font-semibold tracking-wider cursor-pointer transition-all duration-300;
 }
 
 .wafuu-btn-secondary:hover {
-	background: rgba(212, 175, 55, 0.15);
-	border-color: rgba(212, 175, 55, 0.5);
+	@apply bg-[rgba(212,175,55,0.15)] border-[rgba(212,175,55,0.5)];
 }
 
 .wafuu-btn-outline {
-	width: 100%;
-	padding: 10px 0;
-	border: 1px solid rgba(245, 230, 200, 0.15);
-	border-radius: 10px;
-	background: transparent;
-	color: rgba(245, 230, 200, 0.5);
-	font-size: 0.9rem;
-	cursor: pointer;
-	transition: all 0.3s ease;
-	text-align: center;
-	text-decoration: none;
-	display: block;
+	@apply w-full py-2.5 border border-[rgba(245,230,200,0.15)] rounded-xl bg-transparent text-[rgba(245,230,200,0.5)] text-[0.9rem] cursor-pointer transition-all duration-300 text-center no-underline block;
 }
 
 .wafuu-btn-outline:hover {
-	border-color: rgba(245, 230, 200, 0.3);
-	color: rgba(245, 230, 200, 0.8);
+	@apply border-[rgba(245,230,200,0.3)] text-[rgba(245,230,200,0.8)];
 }
 
 /* --- フォーム --- */
 .wafuu-input {
-	width: 100%;
-	padding: 12px 14px;
-	background: rgba(245, 230, 200, 0.06);
-	border: 1px solid rgba(212, 175, 55, 0.15);
-	border-radius: 10px;
-	color: #f5e6c8;
-	font-size: 0.95rem;
-	outline: none;
-	transition: all 0.3s ease;
-	box-sizing: border-box;
+	@apply w-full p-[12px_14px] bg-[rgba(245,230,200,0.06)] border border-[rgba(212,175,55,0.15)] rounded-xl text-[#f5e6c8] text-[0.95rem] outline-none transition-all duration-300 box-border;
 }
 
 .wafuu-input::placeholder {
-	color: rgba(245, 230, 200, 0.25);
+	@apply text-[rgba(245,230,200,0.25)];
 }
 
 .wafuu-input:focus {
-	border-color: rgba(212, 175, 55, 0.5);
-	background: rgba(245, 230, 200, 0.1);
-	box-shadow: 0 0 12px rgba(212, 175, 55, 0.1);
+	@apply border-[rgba(212,175,55,0.5)] bg-[rgba(245,230,200,0.1)] shadow-[0_0_12px_rgba(212,175,55,0.1)];
 }
 
 .wafuu-label {
-	font-size: 0.8rem;
-	color: rgba(245, 230, 200, 0.6);
-	font-weight: 500;
-	letter-spacing: 0.05em;
-	margin-bottom: 6px;
-	display: block;
+	@apply text-[0.8rem] text-[rgba(245,230,200,0.6)] font-medium tracking-wider mb-1.5 block;
 }
 
 /* --- エラー --- */
 .wafuu-error {
-	background: rgba(200, 50, 50, 0.15);
-	border: 1px solid rgba(200, 50, 50, 0.3);
-	border-radius: 10px;
-	padding: 10px 14px;
-	color: #ff8888;
-	font-size: 0.85rem;
-	margin-bottom: 12px;
+	@apply bg-[rgba(200,50,50,0.15)] border border-[rgba(200,50,50,0.3)] rounded-xl p-[10px_14px] text-[#ff8888] text-[0.85rem] mb-3;
 }
 
 /* --- ステータスバッジ --- */
 .wafuu-badge {
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-	padding: 4px 12px;
-	border-radius: 20px;
-	font-size: 0.75rem;
-	font-weight: 600;
+	@apply inline-flex items-center gap-1.5 px-3 py-1 rounded-[20px] text-[0.75rem] font-semibold;
 }
 
 .wafuu-badge-success {
-	background: rgba(34, 197, 94, 0.15);
-	color: #4ade80;
-	border: 1px solid rgba(34, 197, 94, 0.2);
+	@apply bg-[rgba(34,197,94,0.15)] text-[#4ade80] border border-[rgba(34,197,94,0.2)];
 }
 
 .wafuu-badge-warning {
-	background: rgba(234, 179, 8, 0.15);
-	color: #fbbf24;
-	border: 1px solid rgba(234, 179, 8, 0.2);
+	@apply bg-[rgba(234,179,8,0.15)] text-[#fbbf24] border border-[rgba(234,179,8,0.2)];
 }
 
 .wafuu-badge-info {
-	background: rgba(59, 130, 246, 0.15);
-	color: #60a5fa;
-	border: 1px solid rgba(59, 130, 246, 0.2);
+	@apply bg-[rgba(59,130,246,0.15)] text-[#60a5fa] border border-[rgba(59,130,246,0.2)];
 }
 
 /* --- 待機アニメーション --- */
 .wafuu-pulse {
-	animation: wafuuPulse 2s ease-in-out infinite;
-}
-
-@keyframes wafuuPulse {
-
-	0%,
-	100% {
-		opacity: 0.5;
-	}
-
-	50% {
-		opacity: 1;
-	}
+	@apply animate-pulse;
 }
 
 /* --- ユーティリティ --- */
 .wafuu-gap-8 {
-	gap: 8px;
+	@apply gap-2;
 }
 
 .wafuu-gap-12 {
-	gap: 12px;
+	@apply gap-3;
 }
 
 .wafuu-gap-16 {
-	gap: 16px;
+	@apply gap-4;
 }
 
 .wafuu-mt-8 {
-	margin-top: 8px;
+	@apply mt-2;
 }
 
 .wafuu-mt-12 {
-	margin-top: 12px;
+	@apply mt-3;
 }
 
 .wafuu-mt-16 {
-	margin-top: 16px;
+	@apply mt-4;
 }
 
 .wafuu-text-center {
-	text-align: center;
+	@apply text-center;
 }
 
 .wafuu-flex-col {
-	display: flex;
-	flex-direction: column;
+	@apply flex flex-col;
 }

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -32,7 +32,10 @@
     "@types/node": "^22.13.10",
     "@types/react": "^19.0.12",
     "@types/react-dom": "^19.0.4",
+    "autoprefixer": "^10.4.27",
+    "postcss": "^8.5.8",
     "prisma": "^6.5.0",
+    "tailwindcss": "^3.4.19",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.2"
   },

--- a/nextjs/postcss.config.js
+++ b/nextjs/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/nextjs/tailwind.config.js
+++ b/nextjs/tailwind.config.js
@@ -1,0 +1,52 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./lib/**/*.{js,ts,jsx,tsx,mdx}",
+    "./hooks/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        bg: "#FFF8EE",
+        "bg-alt": "#F5E6D0",
+        surface: "#FFFFFF",
+        wood: "#D4A574",
+        "wood-dark": "#B8865A",
+        "wood-light": "#E8C9A0",
+        "wood-board": "#D4A060",
+        "wood-line": "#A67840",
+        primary: "#E8834A",
+        "primary-hover": "#D6722E",
+        secondary: "#5B9BD5",
+        "secondary-hover": "#4A88C0",
+        danger: "#E05D5D",
+        "danger-hover": "#CC4444",
+        success: "#5DB87E",
+        text: "#3D2B1F",
+        "text-light": "#7A6555",
+        "text-muted": "#A89585",
+        border: "#E0D0C0",
+        "piece-sente": "#F5E6D0",
+        "piece-gote": "#4A4A4A",
+        "piece-gote-bg": "#E0D0C0",
+      },
+      fontFamily: {
+        wafuu: ["'M PLUS Rounded 1c'", "'Noto Sans JP'", "sans-serif"],
+      },
+      borderRadius: {
+        sm: "8px",
+        md: "12px",
+        lg: "16px",
+        xl: "20px",
+      },
+      boxShadow: {
+        sm: "0 2px 8px rgba(60, 40, 20, 0.12)",
+        md: "0 4px 16px rgba(60, 40, 20, 0.12)",
+        lg: "0 8px 32px rgba(60, 40, 20, 0.2)",
+      },
+    },
+  },
+  plugins: [],
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,10 @@
 				"@types/node": "^22.13.10",
 				"@types/react": "^19.0.12",
 				"@types/react-dom": "^19.0.4",
+				"autoprefixer": "^10.4.27",
+				"postcss": "^8.5.8",
 				"prisma": "^6.5.0",
+				"tailwindcss": "^3.4.19",
 				"ts-node": "^10.9.2",
 				"typescript": "^5.8.2"
 			}
@@ -114,6 +117,35 @@
 				"node-gyp-build-test": "build-test.js"
 			}
 		},
+		"nextjs/node_modules/postcss": {
+			"version": "8.5.8",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.11",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
 		"nextjs/node_modules/socket.io-client": {
 			"version": "4.8.3",
 			"license": "MIT",
@@ -137,6 +169,51 @@
 			"engines": {
 				"node": ">=10.0.0"
 			}
+		},
+		"nextjs/node_modules/tailwindcss": {
+			"version": "3.4.19",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+			"integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@alloc/quick-lru": "^5.2.0",
+				"arg": "^5.0.2",
+				"chokidar": "^3.6.0",
+				"didyoumean": "^1.2.2",
+				"dlv": "^1.1.3",
+				"fast-glob": "^3.3.2",
+				"glob-parent": "^6.0.2",
+				"is-glob": "^4.0.3",
+				"jiti": "^1.21.7",
+				"lilconfig": "^3.1.3",
+				"micromatch": "^4.0.8",
+				"normalize-path": "^3.0.0",
+				"object-hash": "^3.0.0",
+				"picocolors": "^1.1.1",
+				"postcss": "^8.4.47",
+				"postcss-import": "^15.1.0",
+				"postcss-js": "^4.0.1",
+				"postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+				"postcss-nested": "^6.2.0",
+				"postcss-selector-parser": "^6.1.2",
+				"resolve": "^1.22.8",
+				"sucrase": "^3.35.0"
+			},
+			"bin": {
+				"tailwind": "lib/cli.js",
+				"tailwindcss": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"nextjs/node_modules/tailwindcss/node_modules/arg": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+			"integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"nextjs/node_modules/ts-node": {
 			"version": "10.9.2",
@@ -219,6 +296,19 @@
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
+		"node_modules/@alloc/quick-lru": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+			"integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@auth/core": {
 			"version": "0.41.1",
 			"resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.1.tgz",
@@ -295,6 +385,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -311,6 +402,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -327,6 +419,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -343,6 +436,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -359,6 +453,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -375,6 +470,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -391,6 +487,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -407,6 +504,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -423,6 +521,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -439,6 +538,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -455,6 +555,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -471,6 +572,7 @@
 			"cpu": [
 				"loong64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -487,6 +589,7 @@
 			"cpu": [
 				"mips64el"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -503,6 +606,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -519,6 +623,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -535,6 +640,7 @@
 			"cpu": [
 				"s390x"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -551,6 +657,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -567,6 +674,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -583,6 +691,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -599,6 +708,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -615,6 +725,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -631,6 +742,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -647,6 +759,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -663,6 +776,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -679,6 +793,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -695,6 +810,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -702,6 +818,28 @@
 			],
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
 		"node_modules/@jridgewell/resolve-uri": {
@@ -898,6 +1036,44 @@
 			],
 			"engines": {
 				"node": ">= 10"
+			}
+		},
+		"node_modules/@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.stat": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.walk": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/@panva/hkdf": {
@@ -1342,12 +1518,70 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/any-promise": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/anymatch": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/arg": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
 			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/autoprefixer": {
+			"version": "10.4.27",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+			"integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/autoprefixer"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"browserslist": "^4.28.1",
+				"caniuse-lite": "^1.0.30001774",
+				"fraction.js": "^5.3.4",
+				"picocolors": "^1.1.1",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"bin": {
+				"autoprefixer": "bin/autoprefixer"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			},
+			"peerDependencies": {
+				"postcss": "^8.1.0"
+			}
 		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
@@ -1369,6 +1603,19 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.10.13",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
+			"integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/bidi-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -1376,6 +1623,66 @@
 			"license": "MIT",
 			"dependencies": {
 				"require-from-string": "^2.0.2"
+			}
+		},
+		"node_modules/binary-extensions": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+			"integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/braces": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fill-range": "^7.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/browserslist": {
+			"version": "4.28.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"baseline-browser-mapping": "^2.10.12",
+				"caniuse-lite": "^1.0.30001782",
+				"electron-to-chromium": "^1.5.328",
+				"node-releases": "^2.0.36",
+				"update-browserslist-db": "^1.2.3"
+			},
+			"bin": {
+				"browserslist": "cli.js"
+			},
+			"engines": {
+				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
 			}
 		},
 		"node_modules/buffer": {
@@ -1413,6 +1720,16 @@
 				"node": ">=10.16.0"
 			}
 		},
+		"node_modules/camelcase-css": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+			"integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/camera-controls": {
 			"version": "2.10.1",
 			"resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-2.10.1.tgz",
@@ -1423,9 +1740,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001781",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
-			"integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+			"version": "1.0.30001784",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001784.tgz",
+			"integrity": "sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -1442,11 +1759,59 @@
 			],
 			"license": "CC-BY-4.0"
 		},
+		"node_modules/chokidar": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+			"integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"anymatch": "~3.1.2",
+				"braces": "~3.0.2",
+				"glob-parent": "~5.1.2",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.6.0"
+			},
+			"engines": {
+				"node": ">= 8.10.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/chokidar/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/client-only": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
 			"integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
 			"license": "MIT"
+		},
+		"node_modules/commander": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+			"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
 		},
 		"node_modules/create-require": {
 			"version": "1.1.1",
@@ -1487,6 +1852,19 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/cssesc": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"cssesc": "bin/cssesc"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/csstype": {
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1519,6 +1897,13 @@
 				"webgl-constants": "^1.1.1"
 			}
 		},
+		"node_modules/didyoumean": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+			"integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
 		"node_modules/diff": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
@@ -1529,11 +1914,25 @@
 				"node": ">=0.3.1"
 			}
 		},
+		"node_modules/dlv": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+			"integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/draco3d": {
 			"version": "1.5.7",
 			"resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
 			"integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
 			"license": "Apache-2.0"
+		},
+		"node_modules/electron-to-chromium": {
+			"version": "1.5.330",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.330.tgz",
+			"integrity": "sha512-jFNydB5kFtYUobh4IkWUnXeyDbjf/r9gcUEXe1xcrcUxIGfTdzPXA+ld6zBRbwvgIGVzDll/LTIiDztEtckSnA==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/esbuild": {
 			"version": "0.27.4",
@@ -1590,16 +1989,94 @@
 				"esbuild": ">=0.12 <1"
 			}
 		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/fast-glob": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.2",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.8"
+			},
+			"engines": {
+				"node": ">=8.6.0"
+			}
+		},
+		"node_modules/fast-glob/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/fastq": {
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+			"integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"reusify": "^1.0.4"
+			}
+		},
 		"node_modules/fflate": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
 			"integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
 			"license": "MIT"
 		},
+		"node_modules/fill-range": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"to-regex-range": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/fraction.js": {
+			"version": "5.3.4",
+			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+			"integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/rawify"
+			}
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -1608,6 +2085,29 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/glob-parent": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/glsl-noise": {
@@ -1621,6 +2121,19 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"license": "ISC"
+		},
+		"node_modules/hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/hls.js": {
 			"version": "1.6.15",
@@ -1653,6 +2166,68 @@
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
 			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
 			"license": "MIT"
+		},
+		"node_modules/is-binary-path": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"binary-extensions": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-core-module": {
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-glob": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.12.0"
+			}
 		},
 		"node_modules/is-promise": {
 			"version": "2.2.2",
@@ -1687,6 +2262,16 @@
 				"@types/react": "*"
 			}
 		},
+		"node_modules/jiti": {
+			"version": "1.21.7",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+			"integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jiti": "bin/jiti.js"
+			}
+		},
 		"node_modules/jose": {
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
@@ -1710,6 +2295,26 @@
 			"dependencies": {
 				"immediate": "~3.0.5"
 			}
+		},
+		"node_modules/lilconfig": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+			"integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antonk52"
+			}
+		},
+		"node_modules/lines-and-columns": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/loose-envify": {
 			"version": "1.4.0",
@@ -1759,6 +2364,16 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/merge2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/meshline": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
@@ -1774,11 +2389,37 @@
 			"integrity": "sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g==",
 			"license": "MIT"
 		},
+		"node_modules/micromatch": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"braces": "^3.0.3",
+				"picomatch": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=8.6"
+			}
+		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
+		},
+		"node_modules/mz": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"any-promise": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"thenify-all": "^1.0.0"
+			}
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.11",
@@ -1905,6 +2546,23 @@
 				}
 			}
 		},
+		"node_modules/node-releases": {
+			"version": "2.0.36",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+			"integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/oauth4webapi": {
 			"version": "3.8.5",
 			"resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
@@ -1923,6 +2581,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/object-hash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+			"integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/path-key": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -1932,11 +2600,51 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
 			"license": "ISC"
+		},
+		"node_modules/picomatch": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/pirates": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+			"integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
 		},
 		"node_modules/postcss": {
 			"version": "8.4.31",
@@ -1965,6 +2673,140 @@
 			"engines": {
 				"node": "^10 || ^12 || >=14"
 			}
+		},
+		"node_modules/postcss-import": {
+			"version": "15.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+			"integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"postcss-value-parser": "^4.0.0",
+				"read-cache": "^1.0.0",
+				"resolve": "^1.1.7"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.0.0"
+			}
+		},
+		"node_modules/postcss-js": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+			"integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"camelcase-css": "^2.0.1"
+			},
+			"engines": {
+				"node": "^12 || ^14 || >= 16"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.21"
+			}
+		},
+		"node_modules/postcss-load-config": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+			"integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"lilconfig": "^3.1.1"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"jiti": ">=1.21.0",
+				"postcss": ">=8.0.9",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"jiti": {
+					"optional": true
+				},
+				"postcss": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/postcss-nested": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+			"integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"postcss-selector-parser": "^6.1.1"
+			},
+			"engines": {
+				"node": ">=12.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.14"
+			}
+		},
+		"node_modules/postcss-selector-parser": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/postcss-value-parser": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/potpack": {
 			"version": "1.0.2",
@@ -2040,6 +2882,27 @@
 				"object-assign": "^4.1.1",
 				"react-is": "^16.13.1"
 			}
+		},
+		"node_modules/queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/react": {
 			"version": "18.3.1",
@@ -2124,6 +2987,29 @@
 				}
 			}
 		},
+		"node_modules/read-cache": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+			"integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pify": "^2.3.0"
+			}
+		},
+		"node_modules/readdirp": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"picomatch": "^2.2.1"
+			},
+			"engines": {
+				"node": ">=8.10.0"
+			}
+		},
 		"node_modules/require-from-string": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2131,6 +3017,62 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/resolve": {
+			"version": "1.22.11",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+			"integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-core-module": "^2.16.1",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/reusify": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/run-parallel": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"queue-microtask": "^1.2.2"
 			}
 		},
 		"node_modules/scheduler": {
@@ -2229,6 +3171,42 @@
 				}
 			}
 		},
+		"node_modules/sucrase": {
+			"version": "3.35.1",
+			"resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+			"integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.2",
+				"commander": "^4.0.0",
+				"lines-and-columns": "^1.1.6",
+				"mz": "^2.7.0",
+				"pirates": "^4.0.1",
+				"tinyglobby": "^0.2.11",
+				"ts-interface-checker": "^0.1.9"
+			},
+			"bin": {
+				"sucrase": "bin/sucrase",
+				"sucrase-node": "bin/sucrase-node"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/suspend-react": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
@@ -2236,6 +3214,29 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"react": ">=17.0"
+			}
+		},
+		"node_modules/thenify": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"any-promise": "^1.0.0"
+			}
+		},
+		"node_modules/thenify-all": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"thenify": ">= 3.1.0 < 4"
+			},
+			"engines": {
+				"node": ">=0.8"
 			}
 		},
 		"node_modules/three": {
@@ -2277,6 +3278,67 @@
 			"integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
 			"license": "MIT"
 		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.15",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyglobby/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tinyglobby/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-number": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=8.0"
+			}
+		},
 		"node_modules/torassen-nextjs": {
 			"resolved": "nextjs",
 			"link": true
@@ -2314,6 +3376,13 @@
 			"resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
 			"integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
 			"license": "MIT"
+		},
+		"node_modules/ts-interface-checker": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+			"integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
@@ -2372,6 +3441,37 @@
 				"node": ">=14.17"
 			}
 		},
+		"node_modules/update-browserslist-db": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"escalade": "^3.2.0",
+				"picocolors": "^1.1.1"
+			},
+			"bin": {
+				"update-browserslist-db": "cli.js"
+			},
+			"peerDependencies": {
+				"browserslist": ">= 4.21.0"
+			}
+		},
 		"node_modules/use-sync-external-store": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -2380,6 +3480,13 @@
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/utility-types": {
 			"version": "3.11.0",


### PR DESCRIPTION
## 概要
既存のVanilla CSSによるスタイリングシステムを、Tailwind CSSへと移行しました。
プロジェクト独自の和風テーマやカラーパレットをTailwindの設定として統合し、保守性を向上させています。

## 変更点
- [tailwind.config.js](cci:7://file:///Users/kotasakatsume/cursur/ft_tra/nextjs/tailwind.config.js:0:0-0:0) / `postcss.config.js` の新規作成・設定
- [globals.css](cci:7://file:///Users/kotasakatsume/cursur/ft_tra/nextjs/app/globals.css:0:0-0:0), [wafuu-theme.css](cci:7://file:///Users/kotasakatsume/cursur/ft_tra/nextjs/app/wafuu-theme.css:0:0-0:0), [login.css](cci:7://file:///Users/kotasakatsume/cursur/ft_tra/nextjs/app/login/login.css:0:0-0:0) の `@apply` ベースへの移行
- パッケージへの `tailwindcss`, `postcss`, `autoprefixer` の追加
- 独自カラー・フォント・シャドウのTailwindテーマへの登録
