### PR TITLE
持ち駒が勝手に置かれないようにした

### DIFF
--- a/nextjs/app/home/page.tsx
+++ b/nextjs/app/home/page.tsx
@@ -71,7 +71,7 @@ export default function HomePage() {
 						</div>
 						<span className="wafuu-menu-arrow">→</span>
 					</Link>
-				</div>z
+				</div>
 			</div>
 		</div>
 	);

--- a/nextjs/components/Background/Background.tsx
+++ b/nextjs/components/Background/Background.tsx
@@ -7,7 +7,7 @@ import TatamiModel from "./TatamiModel";
 import * as THREE from "three";
 import { RefObject } from "react"
 
-interface Background  {
+interface Background {
     isFlipped: boolean,
     boardGroupRef: RefObject<THREE.Group<THREE.Object3DEventMap> | null>
 }
@@ -24,14 +24,14 @@ export default function Background(props: Background) {
 
                 {/* 自分の駒台 (常に右下) */}
                 <DaiModelContent
-                    position={props.isFlipped ? [-21.2, 0, 12.7] : [-12.5, 0, -21]}
+                    position={props.isFlipped ? [-12.5, 0, -21] : [-21.2, 0, 12.7]}
                     rotation={[0, Math.PI, 0]}
                     scale={[1, 1, 1]}
                 />
 
                 {/* 相手の駒台 (常に左上) */}
                 <DaiModelContent
-                    position={props.isFlipped ? [-12.5, 0, -21] : [-21.2, 0, 12.7]}
+                    position={props.isFlipped ? [-21.2, 0, 12.7] : [-12.5, 0, -21]}
                     rotation={[0, Math.PI, 0]}
                     scale={[1, 1, 1]}
                 />

--- a/nextjs/components/MatchBoard.tsx
+++ b/nextjs/components/MatchBoard.tsx
@@ -156,7 +156,7 @@ function MatchBoard({ roomId, socket, wsStatus = "disconnected", mySide = "sente
 			{gotSfen &&
 				<TatamiBackground
 					state={state}
-					playerColor={mySide === "sente" ? Color.BLACK : Color.WHITE}
+					playerColor={mySide === "sente" ? Color.BLACK : (mySide === "gote" ? Color.WHITE : undefined)}
 					externalTurn={turn === "sente" ? Color.BLACK : Color.WHITE}
 					lastExternalMove={lastMove || undefined}
 					isGameOver={!!gameOver}

--- a/nextjs/components/TatamiBackground.tsx
+++ b/nextjs/components/TatamiBackground.tsx
@@ -97,7 +97,7 @@ export default function TatamiBackground({
 		setPieceOwners(owners);
 		setPiecePromotions(promotions);
 		setPieceId(Object.keys(positions));
-	}, [initialGrid, isFlipped, boardState]);
+	}, [initialGrid]);
 
 	// 盤面の向き：自分が後手(White)の場合は論理的な座標を反転させる
 
@@ -220,7 +220,7 @@ export default function TatamiBackground({
 			// 外部指し手を適用（親への通知は不要）
 			applyMoveTo3D(targetId, move);
 		}
-	}, [lastExternalMove, piecePositions, pieceOwners, boardState.sideToMove, applyMoveTo3D, isFlipped, initialGrid]);
+	}, [lastExternalMove, piecePositions, pieceOwners, boardState.sideToMove, applyMoveTo3D]);
 
 	// 駒が成っているか確認する
 	const isPiecePromoted = useCallback((id: string): boolean => {

--- a/nextjs/components/TatamiBackground.tsx
+++ b/nextjs/components/TatamiBackground.tsx
@@ -13,12 +13,12 @@ import {
 	UNPROMOTE_MAP,
 	type BoardState,
 	type Move,
-    gridToWorld,
-    worldToGrid,
-    checkIsHandPos,
-    SENTE_HAND_COORDS,
-    GOTE_HAND_COORDS,
-    getBasePieceType,
+	gridToWorld,
+	worldToGrid,
+	checkIsHandPos,
+	SENTE_HAND_COORDS,
+	GOTE_HAND_COORDS,
+	getBasePieceType,
 	getPieceRotation,
 	getGridFromBoardState,
 	getInitialDataFromBoardState,
@@ -97,10 +97,10 @@ export default function TatamiBackground({
 		setPieceOwners(owners);
 		setPiecePromotions(promotions);
 		setPieceId(Object.keys(positions));
-	}, [initialGrid]);
+	}, [initialGrid, isFlipped, boardState]);
 
 	// 盤面の向き：自分が後手(White)の場合は論理的な座標を反転させる
-	
+
 
 	// 3D 盤面のみを更新する関数（循環防止、または外部指し手用）
 	const applyMoveTo3D = useCallback((id: string, move: Move) => {
@@ -165,7 +165,7 @@ export default function TatamiBackground({
 		// 自分が動かせる色であること（AI対戦やオンライン対局用）
 		if (playerColor !== undefined && owner !== playerColor) return false;
 		return true;
-	}, [pieceOwners, boardState.sideToMove, playerColor]);
+	}, [pieceOwners, boardState.sideToMove, playerColor, isGameOver]);
 
 	// 指し手を実行する共通関数
 	const executeMove = useCallback((id: string, move: Move) => {
@@ -220,7 +220,7 @@ export default function TatamiBackground({
 			// 外部指し手を適用（親への通知は不要）
 			applyMoveTo3D(targetId, move);
 		}
-	}, [lastExternalMove, piecePositions, pieceOwners, boardState.sideToMove, applyMoveTo3D]);
+	}, [lastExternalMove, piecePositions, pieceOwners, boardState.sideToMove, applyMoveTo3D, isFlipped, initialGrid]);
 
 	// 駒が成っているか確認する
 	const isPiecePromoted = useCallback((id: string): boolean => {
@@ -283,7 +283,7 @@ export default function TatamiBackground({
 				.filter(m => m.type === "move" && fromGrid && m.from.row === fromGrid.row && m.from.col === fromGrid.col)
 				.map(m => m.to);
 		}
-	}, [selectedPiece, boardState, piecePositions, pieceOwners]);
+	}, [selectedPiece, boardState, piecePositions, pieceOwners, isFlipped, initialGrid]);
 
 	const handleDragEnd = useCallback((id: string, newPos: [number, number, number]) => {
 		const toGrid = worldToGrid(newPos[0], newPos[2], isFlipped);
@@ -383,7 +383,7 @@ export default function TatamiBackground({
 		} else {
 			console.log("無効な移動です");
 		}
-	}, [boardState, piecePositions, executeMove, isPiecePromoted]);
+	}, [boardState, piecePositions, executeMove, isPiecePromoted, isFlipped, initialGrid]);
 
 	// 背景クリックで選択解除
 	const handleBackgroundClick = useCallback(() => {
@@ -396,7 +396,7 @@ export default function TatamiBackground({
 		const typeName = parts[1]; // "PAWN", "KING", "PRO_PAWN" など
 
 		if (side === "sente" && typeName === "KING") {
-			return "/models/ousyo_NoTen.glb"; 
+			return "/models/ousyo_NoTen.glb";
 		}
 		const pTypeKey = (PType as any)[typeName];
 		const modelPath = MODEL[pTypeKey as PType];
@@ -437,7 +437,7 @@ export default function TatamiBackground({
 						<ShogiLoader />
 					) : (
 						<>
-							<Background isFlipped={isFlipped} boardGroupRef={boardGroupRef}/>
+							<Background isFlipped={isFlipped} boardGroupRef={boardGroupRef} />
 							{/* 盤と駒を同じグループに入れて一括で傾ける */}
 							<group ref={boardGroupRef} position={[0, -0.9, 0]} rotation={[(Math.PI / 180) * 30, Math.PI / 2, 0]}>
 								{/* 背景クリックで選択解除用の透明な平面 */}
@@ -447,9 +447,9 @@ export default function TatamiBackground({
 								</mesh>
 
 								{/* アシストマーク（移動可能な場所の強調） */}
-								<MoveMarker validMoveDestinations={validMoveDestinations} isFlipped={isFlipped}/>
+								<MoveMarker validMoveDestinations={validMoveDestinations} isFlipped={isFlipped} />
 
-								{pieceId.map(id=> isPrimaryHandPiece(id) && (
+								{pieceId.map(id => isPrimaryHandPiece(id) && (
 									<DraggablePiece
 										key={id}
 										pieceId={id}
@@ -472,7 +472,7 @@ export default function TatamiBackground({
 			</Canvas>
 
 			{/* 成り選択UI */}
-			{pendingPromotion && 
+			{pendingPromotion &&
 				<PromotionButton
 					pendingPromotion={pendingPromotion}
 					setPendingPromotion={setPendingPromotion}

--- a/packages/shogi-logic/src/getInitialDataFromBoardState.ts
+++ b/packages/shogi-logic/src/getInitialDataFromBoardState.ts
@@ -43,7 +43,11 @@ export function getInitialDataFromBoardState(
     Object.entries(state.hands).forEach(([colorStr, hand]) => {
         const color = Number(colorStr) as Color;
         const side = color === Color.BLACK ? "sente" : "gote";
-        const coordsSource = color === Color.BLACK ? SENTE_HAND_COORDS : GOTE_HAND_COORDS;
+        
+        const isOwnerSente = color === Color.BLACK;
+        const coordsSource = isFlipped ? 
+            (isOwnerSente ? GOTE_HAND_COORDS : SENTE_HAND_COORDS) : 
+            (isOwnerSente ? SENTE_HAND_COORDS : GOTE_HAND_COORDS);
 
         Object.entries(hand).forEach(([typeStr, count]) => {
             const pieceType = Number(typeStr) as PType;

--- a/packages/shogi-logic/src/getInitialDataFromBoardState.ts
+++ b/packages/shogi-logic/src/getInitialDataFromBoardState.ts
@@ -10,7 +10,7 @@ export interface InitialBoardData {
 }
 
 export function getInitialDataFromBoardState(
-    state: BoardState, 
+    state: BoardState,
     isFlipped: boolean = false
 ): InitialBoardData {
     const positions: Record<string, [number, number, number]> = {};
@@ -34,7 +34,7 @@ export function getInitialDataFromBoardState(
                 // 各種データを格納
                 positions[uniqueId] = gridToWorld(rowIndex, colIndex, isFlipped);
                 owners[uniqueId] = color;
-                promotions[uniqueId] = pieceType >= PType.PRO_PAWN; 
+                promotions[uniqueId] = pieceType >= PType.PRO_PAWN;
             }
         });
     });
@@ -43,17 +43,13 @@ export function getInitialDataFromBoardState(
     Object.entries(state.hands).forEach(([colorStr, hand]) => {
         const color = Number(colorStr) as Color;
         const side = color === Color.BLACK ? "sente" : "gote";
-        
-        const isOwnerSente = color === Color.BLACK;
-        const coordsSource = isFlipped ? 
-            (isOwnerSente ? GOTE_HAND_COORDS : SENTE_HAND_COORDS) : 
-            (isOwnerSente ? SENTE_HAND_COORDS : GOTE_HAND_COORDS);
+        const coordsSource = color === Color.BLACK ? SENTE_HAND_COORDS : GOTE_HAND_COORDS;
 
         Object.entries(hand).forEach(([typeStr, count]) => {
             const pieceType = Number(typeStr) as PType;
             if (count <= 0) return;
 
-            const baseType = pieceType >=  PType.PRO_PAWN ? (pieceType - PType.PRO_PAWN) : pieceType;
+            const baseType = pieceType >= PType.PRO_PAWN ? (pieceType - PType.PRO_PAWN) : pieceType;
             const typeName = PType[pieceType];
             const handPos = coordsSource[baseType as PieceType] || [0, 10, 0];
 
@@ -61,7 +57,7 @@ export function getInitialDataFromBoardState(
                 const baseHandId = `${side}-${typeName}-hand`;
                 counts[baseHandId] = (counts[baseHandId] || 0) + 1;
                 const uniqueId = `${baseHandId}-${counts[baseHandId]}`;
-                
+
                 positions[uniqueId] = [...handPos];
                 owners[uniqueId] = color;
                 promotions[uniqueId] = false; // 持ち駒は必ず「未成り」

--- a/packages/shogi-logic/src/grid-world.ts
+++ b/packages/shogi-logic/src/grid-world.ts
@@ -35,6 +35,18 @@ export function worldToGrid(x: number, z: number, isFlipped: boolean = false): {
 		}
 	}
 
+	// 盤面の外（閾値以上離れている）ならnullを返す
+	// BOARD_X_COORDS: [3.9, ..., -9.1], BOARD_Z_COORDS: [-6.4, ..., 6.4]
+	const margin = 2.0;
+	const minX = -9.1 - margin;
+	const maxX = 3.9 + margin;
+	const minZ = -6.4 - margin;
+	const maxZ = 6.4 + margin;
+
+	if (x < minX || x > maxX || z < minZ || z > maxZ) {
+		return null;
+	}
+
 	if (isFlipped) {
 		return { row: 4 - bestRow, col: 4 - bestCol };
 	}


### PR DESCRIPTION
## 概要
後手番の際の持ち駒の表示不具合（位置・向きの逆転）の修正と、駒のドラッグ＆ドロップ操作におけるユーザビリティの向上を行いました。

## 変更内容

### 1. 持ち駒の表示位置と向きの修正
- **Background.tsx**: 物理的な駒台（DaiModel）の座標定義が、内部の論理座標と逆転していたため修正しました。
- **getInitialDataFromBoardState.ts**: 視点反転（`isFlipped`）時に、持ち駒の描画座標も正しく入れ替わるようにロジックを更新しました。
- **TatamiBackground.tsx**: 視点や手番が切り替わった際に、駒の位置計算が即座に更新されるよう `useEffect` や `useCallback` の依存配列に `isFlipped` 等を追加しました。

### 2. ドラッグ＆ドロップ操作の改善
- **grid-world.ts**: 盤面の有効範囲（バウンディングボックス）による判定ロジックを追加しました。
- **自動着手の防止**: 駒を盤面以外の場所（駒台や盤外）で離した場合に、勝手に一番近いマスにスナップして打たれてしまう挙動を修正しました。
- **スナップバック挙動**: 盤面外で離した際や、クリックのみで離した場合は、自動的に元の位置（駒台または移動前のマス）へ戻るようにしました。
