### PR TITLE
観戦者のリザルト修正

### DIFF
--- a/nextjs/components/MatchBoard.tsx
+++ b/nextjs/components/MatchBoard.tsx
@@ -225,6 +225,7 @@ function MatchBoard({ roomId, socket, wsStatus = "disconnected", mySide = "sente
 					{/* Result Overlay */}
 					{showResultOverlay && <ShowResultOverlay
 						isWinner={gameResult.winner === mySide}
+						isSpectator={mySide === "spectator"}
 						gameResult={gameOver as string}
 						clickHandler={setShowResultOverlay}
 					/>}

--- a/nextjs/components/Overlay/ShowResultOverlay.tsx
+++ b/nextjs/components/Overlay/ShowResultOverlay.tsx
@@ -1,14 +1,28 @@
 import Link from "next/link";
 import VictoryAnimation from "./VictoryAnimation";
 import DefeatAnimation from "./DefeatAnimation";
+import SpectatorAnimation from "./SpectatorAnimation";
 
-interface ShowResultOverlay {
+interface ShowResultOverlayProps {
     isWinner: boolean,
+    isSpectator?: boolean,
     gameResult: string,
     clickHandler: (show: boolean) => void;
 }
 
-function ShowResultOverlay({ isWinner, gameResult, clickHandler }:ShowResultOverlay) {
+function ShowResultOverlay({ isWinner, isSpectator, gameResult, clickHandler }: ShowResultOverlayProps) {
+    const statusText = isSpectator ? "終局" : (isWinner ? "勝利" : "敗北");
+    const statusColor = isSpectator ? "#f5e6c8" : (isWinner ? "#d4af37" : "#888");
+    const borderColor = isSpectator 
+        ? "rgba(245, 230, 200, 0.3)" 
+        : (isWinner ? "rgba(212, 175, 55, 0.4)" : "rgba(150, 150, 150, 0.2)");
+    const shadowColor = isSpectator 
+        ? "rgba(245, 230, 200, 0.1)" 
+        : (isWinner ? "rgba(212, 175, 55, 0.2)" : "rgba(0, 0, 0, 0.3)");
+    const buttonBg = isSpectator
+        ? "rgba(245, 230, 200, 0.8)"
+        : (isWinner ? "rgba(212, 175, 55, 0.9)" : "rgba(100, 100, 100, 0.8)");
+
     return (
         <div
             style={{
@@ -29,12 +43,8 @@ function ShowResultOverlay({ isWinner, gameResult, clickHandler }:ShowResultOver
                     background: "rgba(20, 15, 10, 0.95)",
                     padding: "60px 80px",
                     borderRadius: "32px",
-                    border: `2px solid ${isWinner
-                        ? "rgba(212, 175, 55, 0.4)"
-                        : "rgba(150, 150, 150, 0.2)"}`,
-                    boxShadow: `0 0 60px ${isWinner
-                        ? "rgba(212, 175, 55, 0.2)"
-                        : "rgba(0, 0, 0, 0.3)"}`,
+                    border: `2px solid ${borderColor}`,
+                    boxShadow: `0 0 60px ${shadowColor}`,
                     textAlign: "center",
                     minWidth: "400px",
                     animation: "resultPop 0.6s cubic-bezier(0.175, 0.885, 0.32, 1.275)"
@@ -43,7 +53,7 @@ function ShowResultOverlay({ isWinner, gameResult, clickHandler }:ShowResultOver
             >
                 {/* 結果アイコン */}
                 <div style={{ fontSize: "5rem", marginBottom: "20px" }}>
-                    {isWinner ? <VictoryAnimation /> : <DefeatAnimation />}
+                    {isSpectator ? <SpectatorAnimation /> : (isWinner ? <VictoryAnimation /> : <DefeatAnimation />)}
                 </div>
 
                 {/* 結果テキスト */}
@@ -52,15 +62,15 @@ function ShowResultOverlay({ isWinner, gameResult, clickHandler }:ShowResultOver
                         fontSize: "4.5rem",
                         fontWeight: 900,
                         letterSpacing: "0.2em",
-                        color: isWinner ? "#d4af37" : "#888",
-                        textShadow: isWinner
+                        color: statusColor,
+                        textShadow: !isSpectator && isWinner
                             ? "0 0 40px rgba(212, 175, 55, 0.6)"
                             : "0 0 20px rgba(255, 255, 255, 0.1)",
                         margin: "0 0 24px",
                         fontFamily: "'M PLUS Rounded 1c', sans-serif"
                     }}
                 >
-                    {isWinner ? "勝利" : "敗北"}
+                    {statusText}
                 </h2>
 
                 <p
@@ -85,17 +95,13 @@ function ShowResultOverlay({ isWinner, gameResult, clickHandler }:ShowResultOver
                         href="/home"
                         style={{
                             padding: "16px 32px",
-                            background: isWinner
-                                ? "rgba(212, 175, 55, 0.9)"
-                                : "rgba(100, 100, 100, 0.8)",
+                            background: buttonBg,
                             color: "#000",
                             borderRadius: "16px",
                             fontWeight: 900,
                             fontSize: "1.1rem",
                             textDecoration: "none",
-                            boxShadow: `0 4px 15px ${isWinner
-                                ? "rgba(212, 175, 55, 0.4)"
-                                : "rgba(0, 0, 0, 0.2)"}`,
+                            boxShadow: `0 4px 15px ${shadowColor}`,
                             transition: "all 0.2s"
                         }}
                     >

--- a/nextjs/components/Overlay/SpectatorAnimation.tsx
+++ b/nextjs/components/Overlay/SpectatorAnimation.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Lottie from "lottie-react";
+
+export default function SpectatorAnimation() {
+    const [animationData, setAnimationData] = useState<any>(null);
+
+    useEffect(() => {
+        fetch("https://fonts.gstatic.com/s/e/notoemoji/latest/1f917/lottie.json")
+            .then((res) => res.json())
+            .then((data) => setAnimationData(data))
+            .catch((err) => console.error("Failed to load Lottie animation:", err));
+    }, []);
+
+    if (!animationData) return <div style={{ width: "120px", height: "120px", margin: "0 auto", marginBottom: "20px" }} />;
+
+    return (
+        <div style={{ width: "120px", height: "120px", margin: "0 auto", marginBottom: "20px" }}>
+            <Lottie animationData={animationData} loop={true} />
+        </div>
+    );
+}

--- a/nextjs/hooks/useGameLogic.ts
+++ b/nextjs/hooks/useGameLogic.ts
@@ -85,7 +85,9 @@ export function useGameLogic(mySide: "sente" | "gote" | "spectator") {
 			const isWin = winner === mySide;
 
 			const mainMessage = isCheck ? "詰みです！" : "合法手がありません。";
-			const resultMessage = isWin ? "あなたの勝ちです！" : "あなたの負けです。";
+			const resultMessage = mySide === "spectator" 
+				? `${winner === "sente" ? "先手" : "後手"}の勝ちです！`
+				: (winner === mySide ? "あなたの勝ちです！" : "あなたの負けです。");
 
 			dispatch({
 				type: "SET_GAME_OVER",

--- a/nextjs/hooks/useShogiGame.ts
+++ b/nextjs/hooks/useShogiGame.ts
@@ -96,7 +96,7 @@ export function useShogiGame(
 
 			// 自分の勝敗に合わせてメッセージを書き換える
 			let displayMessage = data.message;
-			if (data.winner) {
+			if (data.winner && mySide !== "spectator") {
 				const isWin = data.winner === mySide;
 				displayMessage = isWin ? "あなたの勝ちです！" : "あなたの負けです。";
 				if (data.message.includes("投了")) {
@@ -204,6 +204,7 @@ export function useShogiGame(
 	const handleEndMatch = async () => {
 		if (mySide === "spectator") {
 			router.push("/home");
+			return;
 		}
 		if (gameResult.isOver) {
 			const isWin = gameResult.winner === mySide;


### PR DESCRIPTION
### タイトル
観戦者のリザルト表示および対局終了メッセージの修正

### 概要
観戦モードにおいて、対局終了およびプレイヤー投了時に自身が「敗北」したかのような表示（メッセージおよび演出）がなされる問題を修正しました。

#### 主な変更内容
- **対局終了メッセージの修正**:
    - [useShogiGame.ts](cci:7://file:///Users/kotasakatsume/cursur/ft_tra/nextjs/hooks/useShogiGame.ts:0:0-0:0) および [useGameLogic.ts](cci:7://file:///Users/kotasakatsume/cursur/ft_tra/nextjs/hooks/useGameLogic.ts:0:0-0:0) を修正。観戦者の場合は「あなたの負けです」ではなく、対局結果に基づいた客観的なメッセージ（例：「◯◯の勝ちです」）を表示するようにしました。
- **リザルトオーバーレイの観戦者対応**:
    - [ShowResultOverlay.tsx](cci:7://file:///Users/kotasakatsume/cursur/ft_tra/nextjs/components/Overlay/ShowResultOverlay.tsx:0:0-0:0) に `isSpectator` プロップを追加。観戦者の場合にはタイトルを「終局」とし、中立的なカラーリング（クリーム色ベース、アイコンは🤗）に変更しました。
- **挙動の適正化**:
    - 観戦者が退出（ボタンが「退出する」に変化）した際に、不要な処理をスキップしてスムーズにホームへ戻るように修正。

#### 修正ファイル
- [nextjs/hooks/useShogiGame.ts](cci:7://file:///Users/kotasakatsume/cursur/ft_tra/nextjs/hooks/useShogiGame.ts:0:0-0:0)
- [nextjs/hooks/useGameLogic.ts](cci:7://file:///Users/kotasakatsume/cursur/ft_tra/nextjs/hooks/useGameLogic.ts:0:0-0:0)
- [nextjs/components/MatchBoard.tsx](cci:7://file:///Users/kotasakatsume/cursur/ft_tra/nextjs/components/MatchBoard.tsx:0:0-0:0)
- [nextjs/components/Overlay/ShowResultOverlay.tsx](cci:7://file:///Users/kotasakatsume/cursur/ft_tra/nextjs/components/Overlay/ShowResultOverlay.tsx:0:0-0:0)
- `nextjs/components/Overlay/SpectatorAnimation.tsx` (新規追加)
