### PR TITLE
npm -audit ただしメインバージョン変更ない範囲

### DIFF
--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -20,7 +20,7 @@
     "@types/three": "^0.183.1",
     "argon2": "^0.41.1",
     "lottie-react": "^2.4.1",
-    "next": "14.2.29",
+    "next": "^14.2.35",
     "next-auth": "^5.0.0-beta.30",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -20,7 +20,7 @@
     "@types/three": "^0.183.1",
     "argon2": "^0.41.1",
     "lottie-react": "^2.4.1",
-    "next": "^14.2.35",
+    "next": "14.2.35",
     "next-auth": "^5.0.0-beta.30",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"@types/three": "^0.183.1",
 				"argon2": "^0.41.1",
 				"lottie-react": "^2.4.1",
-				"next": "14.2.29",
+				"next": "^14.2.35",
 				"next-auth": "^5.0.0-beta.30",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
@@ -49,10 +49,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"nextjs/node_modules/@socket.io/component-emitter": {
-			"version": "3.1.2",
-			"license": "MIT"
 		},
 		"nextjs/node_modules/@types/node": {
 			"version": "22.19.13",
@@ -154,17 +150,6 @@
 				"debug": "~4.4.1",
 				"engine.io-client": "~6.6.1",
 				"socket.io-parser": "~4.2.4"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
-		"nextjs/node_modules/socket.io-parser": {
-			"version": "4.2.5",
-			"license": "MIT",
-			"dependencies": {
-				"@socket.io/component-emitter": "~3.1.0",
-				"debug": "~4.4.1"
 			},
 			"engines": {
 				"node": ">=10.0.0"
@@ -385,7 +370,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -402,7 +386,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -419,7 +402,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -436,7 +418,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -453,7 +434,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -470,7 +450,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -487,7 +466,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -504,7 +482,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -521,7 +498,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -538,7 +514,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -555,7 +530,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -572,7 +546,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -589,7 +562,6 @@
 			"cpu": [
 				"mips64el"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -606,7 +578,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -623,7 +594,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -640,7 +610,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -657,7 +626,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -674,7 +642,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -691,7 +658,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -708,7 +674,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -725,7 +690,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -742,7 +706,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -759,7 +722,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -776,7 +738,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -793,7 +754,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -810,7 +770,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -889,15 +848,15 @@
 			}
 		},
 		"node_modules/@next/env": {
-			"version": "14.2.29",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.29.tgz",
-			"integrity": "sha512-UzgLR2eBfhKIQt0aJ7PWH7XRPYw7SXz0Fpzdl5THjUnvxy4kfBk9OU4RNPNiETewEEtaBcExNFNn1QWH8wQTjg==",
+			"version": "14.2.35",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+			"integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
 			"license": "MIT"
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "14.2.29",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.29.tgz",
-			"integrity": "sha512-wWtrAaxCVMejxPHFb1SK/PVV1WDIrXGs9ki0C/kUM8ubKHQm+3hU9MouUywCw8Wbhj3pewfHT2wjunLEr/TaLA==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+			"integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
 			"cpu": [
 				"arm64"
 			],
@@ -911,9 +870,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "14.2.29",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.29.tgz",
-			"integrity": "sha512-7Z/jk+6EVBj4pNLw/JQrvZVrAh9Bv8q81zCFSfvTMZ51WySyEHWVpwCEaJY910LyBftv2F37kuDPQm0w9CEXyg==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+			"integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
 			"cpu": [
 				"x64"
 			],
@@ -927,9 +886,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "14.2.29",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.29.tgz",
-			"integrity": "sha512-o6hrz5xRBwi+G7JFTHc+RUsXo2lVXEfwh4/qsuWBMQq6aut+0w98WEnoNwAwt7hkEqegzvazf81dNiwo7KjITw==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+			"integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
 			"cpu": [
 				"arm64"
 			],
@@ -943,9 +902,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "14.2.29",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.29.tgz",
-			"integrity": "sha512-9i+JEHBOVgqxQ92HHRFlSW1EQXqa/89IVjtHgOqsShCcB/ZBjTtkWGi+SGCJaYyWkr/lzu51NTMCfKuBf7ULNw==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+			"integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
 			"cpu": [
 				"arm64"
 			],
@@ -959,9 +918,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "14.2.29",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.29.tgz",
-			"integrity": "sha512-B7JtMbkUwHijrGBOhgSQu2ncbCYq9E7PZ7MX58kxheiEOwdkM+jGx0cBb+rN5AeqF96JypEppK6i/bEL9T13lA==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+			"integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
 			"cpu": [
 				"x64"
 			],
@@ -975,9 +934,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "14.2.29",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.29.tgz",
-			"integrity": "sha512-yCcZo1OrO3aQ38B5zctqKU1Z3klOohIxug6qdiKO3Q3qNye/1n6XIs01YJ+Uf+TdpZQ0fNrOQI2HrTLF3Zprnw==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+			"integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
 			"cpu": [
 				"x64"
 			],
@@ -991,9 +950,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "14.2.29",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.29.tgz",
-			"integrity": "sha512-WnrfeOEtTVidI9Z6jDLy+gxrpDcEJtZva54LYC0bSKQqmyuHzl0ego+v0F/v2aXq0am67BRqo/ybmmt45Tzo4A==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+			"integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1007,9 +966,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-ia32-msvc": {
-			"version": "14.2.29",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.29.tgz",
-			"integrity": "sha512-vkcriFROT4wsTdSeIzbxaZjTNTFKjSYmLd8q/GVH3Dn8JmYjUKOuKXHK8n+lovW/kdcpIvydO5GtN+It2CvKWA==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+			"integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
 			"cpu": [
 				"ia32"
 			],
@@ -1023,9 +982,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "14.2.29",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.29.tgz",
-			"integrity": "sha512-iPPwUEKnVs7pwR0EBLJlwxLD7TTHWS/AoVZx1l9ZQzfQciqaFEr5AlYzA2uB6Fyby1IF18t4PL0nTpB+k4Tzlw==",
+			"version": "14.2.33",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+			"integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
 			"cpu": [
 				"x64"
 			],
@@ -1356,6 +1315,12 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/@socket.io/component-emitter": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+			"integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+			"license": "MIT"
 		},
 		"node_modules/@swc/counter": {
 			"version": "0.1.3",
@@ -2076,7 +2041,6 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -2440,13 +2404,12 @@
 			}
 		},
 		"node_modules/next": {
-			"version": "14.2.29",
-			"resolved": "https://registry.npmjs.org/next/-/next-14.2.29.tgz",
-			"integrity": "sha512-s98mCOMOWLGGpGOfgKSnleXLuegvvH415qtRZXpSp00HeEgdmrxmwL9cgKU+h4XrhB16zEI5d/7BnkS3ATInsA==",
-			"deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.",
+			"version": "14.2.35",
+			"resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+			"integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
 			"license": "MIT",
 			"dependencies": {
-				"@next/env": "14.2.29",
+				"@next/env": "14.2.35",
 				"@swc/helpers": "0.5.5",
 				"busboy": "1.6.0",
 				"caniuse-lite": "^1.0.30001579",
@@ -2461,15 +2424,15 @@
 				"node": ">=18.17.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-darwin-arm64": "14.2.29",
-				"@next/swc-darwin-x64": "14.2.29",
-				"@next/swc-linux-arm64-gnu": "14.2.29",
-				"@next/swc-linux-arm64-musl": "14.2.29",
-				"@next/swc-linux-x64-gnu": "14.2.29",
-				"@next/swc-linux-x64-musl": "14.2.29",
-				"@next/swc-win32-arm64-msvc": "14.2.29",
-				"@next/swc-win32-ia32-msvc": "14.2.29",
-				"@next/swc-win32-x64-msvc": "14.2.29"
+				"@next/swc-darwin-arm64": "14.2.33",
+				"@next/swc-darwin-x64": "14.2.33",
+				"@next/swc-linux-arm64-gnu": "14.2.33",
+				"@next/swc-linux-arm64-musl": "14.2.33",
+				"@next/swc-linux-x64-gnu": "14.2.33",
+				"@next/swc-linux-x64-musl": "14.2.33",
+				"@next/swc-win32-arm64-msvc": "14.2.33",
+				"@next/swc-win32-ia32-msvc": "14.2.33",
+				"@next/swc-win32-x64-msvc": "14.2.33"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.1.0",
@@ -3105,6 +3068,19 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/socket.io-parser": {
+			"version": "4.2.6",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+			"integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+			"license": "MIT",
+			"dependencies": {
+				"@socket.io/component-emitter": "~3.1.0",
+				"debug": "~4.4.1"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3589,10 +3565,6 @@
 				"typescript": "^5.8.2"
 			}
 		},
-		"ws-server/node_modules/@socket.io/component-emitter": {
-			"version": "3.1.2",
-			"license": "MIT"
-		},
 		"ws-server/node_modules/@types/cors": {
 			"version": "2.8.19",
 			"license": "MIT",
@@ -3718,17 +3690,6 @@
 			"dependencies": {
 				"debug": "~4.4.1",
 				"ws": "~8.18.3"
-			}
-		},
-		"ws-server/node_modules/socket.io-parser": {
-			"version": "4.2.5",
-			"license": "MIT",
-			"dependencies": {
-				"@socket.io/component-emitter": "~3.1.0",
-				"debug": "~4.4.1"
-			},
-			"engines": {
-				"node": ">=10.0.0"
 			}
 		},
 		"ws-server/node_modules/ts-node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"@types/three": "^0.183.1",
 				"argon2": "^0.41.1",
 				"lottie-react": "^2.4.1",
-				"next": "^14.2.35",
+				"next": "14.2.35",
 				"next-auth": "^5.0.0-beta.30",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",


### PR DESCRIPTION
ビルドできる

repri@DESKTOP-0R5AABB:~/cloneme/transcendence/nextjs$ npm run build

> torassen-nextjs@1.0.0 build
> next build

  ▲ Next.js 14.2.35

   Creating an optimized production build ...
 ✓ Compiled successfully
 ✓ Linting and checking validity of types    
 ✓ Collecting page data
 ✓ Generating static pages (23/23)
 ✓ Collecting build traces
 ✓ Finalizing page optimization

Route (app)                              Size     First Load JS
┌ ○ /_not-found                          873 B          88.2 kB
├ ƒ /api/auth/[...nextauth]              0 B                0 B
├ ƒ /api/auth/signup                     0 B                0 B
├ ƒ /api/engine/bestmove                 0 B                0 B
├ ƒ /api/friends                         0 B                0 B
├ ƒ /api/friends/[id]                    0 B                0 B
├ ƒ /api/heartbeat                       0 B                0 B
├ ƒ /api/me                              0 B                0 B
├ ƒ /api/profile                         0 B                0 B
├ ƒ /api/profile/avatar                  0 B                0 B
├ ƒ /api/profile/avatar/[id]             0 B                0 B
├ ƒ /api/result                          0 B                0 B
├ ○ /friends                             2.59 kB        98.6 kB
├ ○ /home                                1.31 kB         101 kB
├ ○ /login                               1.46 kB        92.8 kB
├ ○ /match                               4.18 kB         468 kB
├ ƒ /match/[roomId]                      624 B           477 kB
├ ○ /online                              1.55 kB        97.6 kB
├ ○ /privacy                             194 B          96.2 kB
├ ○ /profile                             2.17 kB        98.2 kB
├ ○ /profile/edit                        1.92 kB         102 kB
├ ○ /result                              1.26 kB         177 kB
├ ƒ /room/[roomId]                       2.29 kB         115 kB
├ ○ /spectate                            1.32 kB        97.3 kB
├ ƒ /spectate/[roomId]                   503 B           477 kB
└ ○ /terms                               194 B          96.2 kB
+ First Load JS shared by all            87.3 kB
  ├ chunks/364-e62d96ddbdf5a161.js       31.7 kB
  ├ chunks/618f8807-3636e1ac2039c91d.js  53.6 kB
  └ other shared chunks (total)          1.98 kB


ƒ Middleware                             79.2 kB

○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand

repri@DESKTOP-0R5AABB:~/cloneme/transcendence/nextjs$



警告も減る

repri@DESKTOP-0R5AABB:~/cloneme/transcendence$ npm audit
# npm audit report

next  9.5.0 - 15.5.13
Severity: high
Next.js self-hosted applications vulnerable to DoS via Image Optimizer remotePatterns configuration - https://github.com/advisories/GHSA-9g9p-9gw9-jx7f
Next.js HTTP request deserialization can lead to DoS when using insecure React Server Components - https://github.com/advisories/GHSA-h25m-26qc-wcjf 
Next.js: HTTP request smuggling in rewrites - https://github.com/advisories/GHSA-ggv3-7p47-pfv8
Next.js: Unbounded next/image disk cache growth can exhaust storage - https://github.com/advisories/GHSA-3x4c-7xq6-9pq8
fix available via `npm audit fix --force`
Will install next@16.2.2, which is a breaking change
node_modules/next

1 high severity vulnerability

To address all issues (including breaking changes), run:
  npm audit fix --force
repri@DESKTOP-0R5AABB:~/cloneme/transcendence$


すごい！