### PR TITLE
add chatを進化させたミニマムで動くchat機能

### DIFF
--- a/nextjs/app/match/[roomId]/page.tsx
+++ b/nextjs/app/match/[roomId]/page.tsx
@@ -13,6 +13,7 @@ export default function OnlineMatchPage() {
 	const [socket, setSocket] = useState<Socket | null>(null);
 	const [wsStatus, setWsStatus] = useState<"connected" | "disconnected" | "connecting">("connecting");
 	const [mySide, setMySide] = useState<PlayerSide>("spectator");
+	const [initialMessages, setInitialMessages] = useState<any[]>([]);
 	const userId = useUser();
 
 	useEffect(() => {
@@ -37,8 +38,11 @@ export default function OnlineMatchPage() {
 			setWsStatus("disconnected");
 		});
 
-		s.on("roomState", (state: { players: { socketId: string, userId?: string, side: "b" | "w" }[] }) => {
+		s.on("roomState", (state: { players: { socketId: string, userId?: string, side: "b" | "w" }[], messages?: any[] }) => {
 			// console.log("[WS] Room state update:", state);
+			if (state.messages) {
+				setInitialMessages(state.messages);
+			}
 			const me = state.players.find((p) =>
 				(userId && p.userId === userId) || p.socketId === s.id
 			);
@@ -63,6 +67,7 @@ export default function OnlineMatchPage() {
 			wsStatus={wsStatus}
 			mySide={mySide}
 			isPreparing={wsStatus === "connecting"}
+			initialMessages={initialMessages}
 		/>
 	);
 }

--- a/nextjs/app/match/[roomId]/page.tsx
+++ b/nextjs/app/match/[roomId]/page.tsx
@@ -5,13 +5,14 @@ import { useState, useEffect } from "react";
 import { io, Socket } from "socket.io-client";
 import MatchBoard from "@/components/MatchBoard";
 import { useUser } from "@/hooks/useUser";
+import { PlayerSide } from "@/types/game";
 
 export default function OnlineMatchPage() {
 	const params = useParams();
 	const roomId = params.roomId as string;
 	const [socket, setSocket] = useState<Socket | null>(null);
 	const [wsStatus, setWsStatus] = useState<"connected" | "disconnected" | "connecting">("connecting");
-	const [mySide, setMySide] = useState<"sente" | "gote" | "spectator">("spectator");
+	const [mySide, setMySide] = useState<PlayerSide>("spectator");
 	const userId = useUser();
 
 	useEffect(() => {

--- a/nextjs/app/room/[roomId]/page.tsx
+++ b/nextjs/app/room/[roomId]/page.tsx
@@ -6,6 +6,8 @@ import Link from "next/link";
 import { io, Socket } from "socket.io-client";
 import { useSession } from "next-auth/react";
 import Header from "@/components/Header";
+import Chat from "@/components/Chat/Chat";
+
 
 interface Player {
 	socketId: string;
@@ -245,6 +247,15 @@ export default function RoomPage() {
 					</div>
 				</div>
 			</div>
+
+			{/* チャット画面 */}
+			{socket && roomId && (
+				<Chat
+					socket={socket}
+					roomId={roomId}
+					mySide={amIHost ? "sente" : "gote"}
+				/>
+			)}
 		</div>
 	);
 }

--- a/nextjs/app/room/[roomId]/page.tsx
+++ b/nextjs/app/room/[roomId]/page.tsx
@@ -21,6 +21,7 @@ interface RoomState {
 	hostUserId?: string;
 	players: Player[];
 	sfen?: string;
+	messages?: any[];
 }
 
 export default function RoomPage() {
@@ -254,6 +255,7 @@ export default function RoomPage() {
 					socket={socket}
 					roomId={roomId}
 					mySide={amIHost ? "sente" : "gote"}
+					initialMessages={roomState?.messages}
 				/>
 			)}
 		</div>

--- a/nextjs/app/spectate/[roomId]/page.tsx
+++ b/nextjs/app/spectate/[roomId]/page.tsx
@@ -4,6 +4,7 @@ import MatchBoard from "@/components/MatchBoard";
 import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { io, Socket } from "socket.io-client";
+import { PlayerSide } from "@/types/game";
 
 export default function SpectateRoomPage() {
     const params = useParams();
@@ -11,7 +12,7 @@ export default function SpectateRoomPage() {
 
     const [socket, setSocket] = useState<Socket | null>(null);
     const [wsStatus, setWsStatus] = useState<"connecting" | "connected" | "disconnected">("connecting");
-    const [mySide, setMySide] = useState<"sente" | "gote" | "spectator">("spectator");
+    const [mySide, setMySide] = useState<PlayerSide>("spectator");
 
     useEffect(() => {
         const s = io("http://localhost:3001", {

--- a/nextjs/components/AiMatchBoard.tsx
+++ b/nextjs/components/AiMatchBoard.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import { useSession } from "next-auth/react";
 import { useAiGame } from "@/hooks/useAiGame";
 import { PieceData, Color, PieceType, Move } from "@torassen/shogi-logic";
 import TatamiBackground from "@/components/TatamiBackground";
@@ -36,6 +37,7 @@ interface AiMatchBoardProps {
 function AiMatchBoard({ mySide = "sente", aiDepth = 4, isPreparing = false }: AiMatchBoardProps) {
 	const router = useRouter();
 	const user = useUser();
+	const { data: session } = useSession();
 	const [isLoaded, setIsLoaded] = useState(false);
 
 	const {
@@ -105,7 +107,7 @@ function AiMatchBoard({ mySide = "sente", aiDepth = 4, isPreparing = false }: Ai
 					<Header
 						title="将棋ゲーム"
 						pageName="AI対戦"
-						userName={user}
+						userName={session?.user?.name || undefined}
 						onLogout={handleLogout}
 						logoutLabel="退出"
 					/>

--- a/nextjs/components/Chat/Chat.tsx
+++ b/nextjs/components/Chat/Chat.tsx
@@ -88,7 +88,7 @@ export default function Chat({ socket, roomId, mySide }: ChatProps) {
               handleSend();
             }
           }}
-          placeholder="対局中チャット..."
+          placeholder={`${userName}として発言...`}
         />
         <button className="chat-send-btn" onClick={handleSend}>
           ⇧

--- a/nextjs/components/Chat/Chat.tsx
+++ b/nextjs/components/Chat/Chat.tsx
@@ -83,7 +83,7 @@ export default function Chat({ socket, roomId, mySide }: ChatProps) {
           placeholder="対局中チャット..."
         />
         <button className="chat-send-btn" onClick={handleSend}>
-          墨
+          ⇧
         </button>
       </div>
 

--- a/nextjs/components/Chat/Chat.tsx
+++ b/nextjs/components/Chat/Chat.tsx
@@ -2,19 +2,22 @@
 
 import { useState, useEffect, useRef } from "react";
 import { Socket } from "socket.io-client";
+import { PlayerSide } from "@/types/game";
+
+export const getSideLabel = (side: PlayerSide) =>
+  side === "sente" ? "先手" : side === "gote" ? "後手" : "観戦者";
 
 interface Message {
   id: string;
-  sender: string;
   text: string;
-  side?: "sente" | "gote" | "spectator";
+  side: PlayerSide;
   timestamp: number;
 }
 
 interface ChatProps {
   socket: Socket | null | undefined;
   roomId: string;
-  mySide: "sente" | "gote" | "spectator";
+  mySide: PlayerSide;
 }
 
 export default function Chat({ socket, roomId, mySide }: ChatProps) {
@@ -47,7 +50,6 @@ export default function Chat({ socket, roomId, mySide }: ChatProps) {
 
     const newMessage: Message = {
       id: Math.random().toString(36).substr(2, 9),
-      sender: mySide === "sente" ? "先手" : mySide === "gote" ? "後手" : "観戦者",
       text: inputValue.trim(),
       side: mySide,
       timestamp: Date.now(),
@@ -64,7 +66,7 @@ export default function Chat({ socket, roomId, mySide }: ChatProps) {
       <div className="chat-messages" ref={scrollRef}>
         {messages.map((msg) => (
           <div key={msg.id} className={`chat-message chat-side-${msg.side}`}>
-            <span className="chat-sender">[{msg.sender}]</span>
+            <span className="chat-sender">[{getSideLabel(msg.side)}]</span>
             <span className="chat-text">{msg.text}</span>
           </div>
         ))}

--- a/nextjs/components/Chat/Chat.tsx
+++ b/nextjs/components/Chat/Chat.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { Socket } from "socket.io-client";
+
+interface Message {
+  id: string;
+  sender: string;
+  text: string;
+  side?: "sente" | "gote" | "spectator";
+  timestamp: number;
+}
+
+interface ChatProps {
+  socket: Socket | null | undefined;
+  roomId: string;
+  mySide: "sente" | "gote" | "spectator";
+}
+
+export default function Chat({ socket, roomId, mySide }: ChatProps) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [inputValue, setInputValue] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleChatMessage = (msg: Message) => {
+      setMessages((prev) => [...prev, msg]);
+    };
+
+    socket.on("chat", handleChatMessage);
+
+    return () => {
+      socket.off("chat", handleChatMessage);
+    };
+  }, [socket]);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages]);
+
+  const handleSend = () => {
+    if (!socket || !inputValue.trim()) return;
+
+    const newMessage: Message = {
+      id: Math.random().toString(36).substr(2, 9),
+      sender: mySide === "sente" ? "先手" : mySide === "gote" ? "後手" : "観戦者",
+      text: inputValue.trim(),
+      side: mySide,
+      timestamp: Date.now(),
+    };
+
+    socket.emit("chat", { roomId, message: newMessage });
+    // ローカルにも即座に反映（サーバーがBroadcastしない場合も考慮、またはサーバーが自分以外に送る場合）
+    setMessages((prev) => [...prev, newMessage]);
+    setInputValue("");
+  };
+
+  return (
+    <div className="chat-container">
+      <div className="chat-messages" ref={scrollRef}>
+        {messages.map((msg) => (
+          <div key={msg.id} className={`chat-message chat-side-${msg.side}`}>
+            <span className="chat-sender">[{msg.sender}]</span>
+            <span className="chat-text">{msg.text}</span>
+          </div>
+        ))}
+      </div>
+      <div className="chat-input-area">
+        <input
+          type="text"
+          className="chat-input"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+              handleSend();
+            }
+          }}
+          placeholder="対局中チャット..."
+        />
+        <button className="chat-send-btn" onClick={handleSend}>
+          墨
+        </button>
+      </div>
+
+      <style jsx>{`
+        .chat-container {
+          position: fixed;
+          bottom: 80px;
+          left: 20px;
+          width: 280px;
+          height: 200px;
+          background: rgba(20, 15, 10, 0.7);
+          backdrop-filter: blur(8px);
+          border: 1px solid rgba(212, 175, 55, 0.3);
+          border-radius: 12px;
+          display: flex;
+          flex-direction: column;
+          z-index: 100;
+          pointer-events: auto;
+          box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+          overflow: hidden;
+        }
+
+        .chat-messages {
+          flex: 1;
+          padding: 8px;
+          overflow-y: auto;
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+        }
+
+        .chat-messages::-webkit-scrollbar {
+          width: 6px;
+        }
+        .chat-messages::-webkit-scrollbar-thumb {
+          background: rgba(212, 175, 55, 0.2);
+          border-radius: 3px;
+        }
+
+        .chat-message {
+          font-size: 0.8rem;
+          line-height: 1.4;
+          word-break: break-all;
+        }
+
+        .chat-sender {
+          font-weight: bold;
+          margin-right: 6px;
+          color: rgba(245, 230, 200, 0.6);
+        }
+
+        .chat-side-sente .chat-sender {
+          color: #d4af37;
+        }
+        .chat-side-gote .chat-sender {
+          color: #6b8f63;
+        }
+
+        .chat-text {
+          color: #f5e6c8;
+        }
+
+        .chat-input-area {
+          padding: 10px;
+          background: rgba(10, 8, 5, 0.5);
+          border-top: 1px solid rgba(212, 175, 55, 0.15);
+          display: flex;
+          gap: 8px;
+        }
+
+        .chat-input {
+          flex: 1;
+          background: rgba(245, 230, 200, 0.05);
+          border: 1px solid rgba(212, 175, 55, 0.2);
+          border-radius: 6px;
+          padding: 6px 10px;
+          color: #f5e6c8;
+          font-size: 0.85rem;
+          outline: none;
+        }
+
+        .chat-input:focus {
+          border-color: rgba(212, 175, 55, 0.5);
+        }
+
+        .chat-send-btn {
+          background: linear-gradient(135deg, #b8860b, #d4af37);
+          border: none;
+          border-radius: 6px;
+          color: #1a1208;
+          font-weight: bold;
+          padding: 0 12px;
+          cursor: pointer;
+          transition: all 0.2s;
+          font-size: 0.8rem;
+        }
+
+        .chat-send-btn:hover {
+          filter: brightness(1.2);
+          transform: translateY(-1px);
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/nextjs/components/Chat/Chat.tsx
+++ b/nextjs/components/Chat/Chat.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { Socket } from "socket.io-client";
+import { useSession } from "next-auth/react";
 import { PlayerSide } from "@/types/game";
 
 export const getSideLabel = (side: PlayerSide) =>
@@ -9,6 +10,7 @@ export const getSideLabel = (side: PlayerSide) =>
 
 interface Message {
   id: string;
+  name: string;
   text: string;
   side: PlayerSide;
   timestamp: number;
@@ -21,6 +23,9 @@ interface ChatProps {
 }
 
 export default function Chat({ socket, roomId, mySide }: ChatProps) {
+  const { data: session } = useSession();
+  const userName = session?.user?.name || "ゲスト";
+
   const [messages, setMessages] = useState<Message[]>([]);
   const [inputValue, setInputValue] = useState("");
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -50,6 +55,7 @@ export default function Chat({ socket, roomId, mySide }: ChatProps) {
 
     const newMessage: Message = {
       id: Math.random().toString(36).substr(2, 9),
+      name: userName,
       text: inputValue.trim(),
       side: mySide,
       timestamp: Date.now(),
@@ -66,7 +72,7 @@ export default function Chat({ socket, roomId, mySide }: ChatProps) {
       <div className="chat-messages" ref={scrollRef}>
         {messages.map((msg) => (
           <div key={msg.id} className={`chat-message chat-side-${msg.side}`}>
-            <span className="chat-sender">[{getSideLabel(msg.side)}]</span>
+            <span className="chat-sender">[{getSideLabel(msg.side)}]：{msg.name}</span>
             <span className="chat-text">{msg.text}</span>
           </div>
         ))}

--- a/nextjs/components/Chat/Chat.tsx
+++ b/nextjs/components/Chat/Chat.tsx
@@ -20,15 +20,22 @@ interface ChatProps {
   socket: Socket | null | undefined;
   roomId: string;
   mySide: PlayerSide;
+  initialMessages?: Message[];
 }
 
-export default function Chat({ socket, roomId, mySide }: ChatProps) {
+export default function Chat({ socket, roomId, mySide, initialMessages }: ChatProps) {
   const { data: session } = useSession();
   const userName = session?.user?.name || "ゲスト";
 
   const [messages, setMessages] = useState<Message[]>([]);
   const [inputValue, setInputValue] = useState("");
   const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (initialMessages && messages.length === 0) {
+      setMessages(initialMessages);
+    }
+  }, [initialMessages]);
 
   useEffect(() => {
     if (!socket) return;

--- a/nextjs/components/MatchBoard.tsx
+++ b/nextjs/components/MatchBoard.tsx
@@ -8,6 +8,7 @@ import { useShogiGame } from "@/hooks/useShogiGame";
 import { Color, PieceType, PType, Hand, Piece, UIBoard, BoardState, Move, HandPieces } from "@torassen/shogi-logic";
 import TatamiBackground from "@/components/TatamiBackground";
 import { useUser } from "@/hooks/useUser";
+import { PlayerSide } from "@/types/game";
 import GameStatusBanner from "./GamaStatusBanner/GamaStatusBanner";
 import EnemyInfo from "./Info/EnemyInfo";
 import MyInfo from "./Info/MyInfo";
@@ -92,7 +93,7 @@ interface MatchBoardProps {
 	roomId?: string;
 	socket?: Socket | null;
 	wsStatus?: "connected" | "disconnected" | "connecting";
-	mySide?: "sente" | "gote" | "spectator";
+	mySide?: PlayerSide;
 	isPreparing?: boolean;
 }
 

--- a/nextjs/components/MatchBoard.tsx
+++ b/nextjs/components/MatchBoard.tsx
@@ -16,6 +16,8 @@ import GameResultButton from "./Button/GameResult";
 import ShowResultOverlay from "./Overlay/ShowResultOverlay";
 import OteOverlay from "@/components/Overlay/OteOverlay";
 import Header from "@/components/Header";
+import Chat from "./Chat/Chat";
+
 
 export const PIECE_TYPE_TO_KANJI: Record<number, string> = {
 	[PieceType.PAWN]: "歩",
@@ -41,49 +43,49 @@ export const KANJI_TO_PTYPE: Record<string, PType> = {
 };
 
 const convertHandPiecesToHand = (handPieces: HandPieces): Hand => {
-  const hand: Hand = {};
+	const hand: Hand = {};
 
-  Object.entries(handPieces).forEach(([kanji, count]) => {
-    let type = KANJI_TO_PTYPE[kanji];
+	Object.entries(handPieces).forEach(([kanji, count]) => {
+		let type = KANJI_TO_PTYPE[kanji];
 
-    if (type >= PType.PRO_PAWN) {
-      type = (type - 6) as PType;
-    }
+		if (type >= PType.PRO_PAWN) {
+			type = (type - 6) as PType;
+		}
 
-    hand[type] = (hand[type] || 0) + count;
-  });
+		hand[type] = (hand[type] || 0) + count;
+	});
 
-  return hand;
+	return hand;
 };
 
 export function uiBoardToBoardState(uiBoard: UIBoard, moveCount: number = 0): BoardState {
-  // 1. 盤面（board）の変換
-  const board: (Piece | null)[][] = uiBoard.board.map((row) =>
-    row.map((cell) => {
-      if (!cell) return null;
+	// 1. 盤面（board）の変換
+	const board: (Piece | null)[][] = uiBoard.board.map((row) =>
+		row.map((cell) => {
+			if (!cell) return null;
 
-      const pieceType = KANJI_TO_PTYPE[cell.kanji];
-      if (pieceType === undefined) return null;
+			const pieceType = KANJI_TO_PTYPE[cell.kanji];
+			if (pieceType === undefined) return null;
 
-      return {
-        color: cell.side === "sente" ? Color.BLACK : Color.WHITE,
-        pieceType: pieceType,
-      };
-    })
-  );
+			return {
+				color: cell.side === "sente" ? Color.BLACK : Color.WHITE,
+				pieceType: pieceType,
+			};
+		})
+	);
 
-  const hands: [Hand, Hand] = [
-    { ...convertHandPiecesToHand(uiBoard.senteHand)},
-    { ...convertHandPiecesToHand(uiBoard.goteHand) },
-  ];
-  const sideToMove = uiBoard.turn === "sente" ? Color.BLACK : Color.WHITE;
+	const hands: [Hand, Hand] = [
+		{ ...convertHandPiecesToHand(uiBoard.senteHand) },
+		{ ...convertHandPiecesToHand(uiBoard.goteHand) },
+	];
+	const sideToMove = uiBoard.turn === "sente" ? Color.BLACK : Color.WHITE;
 
-  return {
-    board,
-    hands,
-    sideToMove,
-    moveCount,
-  };
+	return {
+		board,
+		hands,
+		sideToMove,
+		moveCount,
+	};
 }
 
 interface MatchBoardProps {
@@ -212,11 +214,21 @@ function MatchBoard({ roomId, socket, wsStatus = "disconnected", mySide = "sente
 						{/* 対局終了通知 */}
 						{gameOver && <GameResultButton clickHandler={setShowResultOverlay} />}
 
-						{/* 右上 (対戦相手の情報) */}
+						{/* 右下 (対戦相手の情報) */}
 						<EnemyInfo mySide={mySide} />
+
+						{/* チャット画面 (右下) */}
+						{roomId && (
+							<Chat
+								socket={socket}
+								roomId={roomId}
+								mySide={mySide}
+							/>
+						)}
 
 						{/* 左下 (あなたの情報) */}
 						<MyInfo mySide={mySide} />
+
 
 						{/* 下部のボタン (右下) */}
 						<SarenderButton isGameOver={gameOver !== null} mySide={mySide} clickHandler={handleEndMatch} />

--- a/nextjs/components/MatchBoard.tsx
+++ b/nextjs/components/MatchBoard.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Socket } from "socket.io-client";
+import { useSession } from "next-auth/react";
 import { useShogiGame } from "@/hooks/useShogiGame";
 import { Color, PieceType, PType, Hand, Piece, UIBoard, BoardState, Move, HandPieces } from "@torassen/shogi-logic";
 import TatamiBackground from "@/components/TatamiBackground";
@@ -100,6 +101,7 @@ interface MatchBoardProps {
 function MatchBoard({ roomId, socket, wsStatus = "disconnected", mySide = "sente", isPreparing = false }: MatchBoardProps) {
 	const router = useRouter();
 	const user = useUser();
+	const { data: session } = useSession();
 	const [isLoaded, setIsLoaded] = useState(false);
 
 	const {
@@ -191,7 +193,7 @@ function MatchBoard({ roomId, socket, wsStatus = "disconnected", mySide = "sente
 								</span>
 							)
 						}
-						userName={user}
+						userName={session?.user?.name || undefined}
 						onLogout={handleLogout}
 						logoutLabel="ログアウト"
 					/>

--- a/nextjs/components/MatchBoard.tsx
+++ b/nextjs/components/MatchBoard.tsx
@@ -96,9 +96,10 @@ interface MatchBoardProps {
 	wsStatus?: "connected" | "disconnected" | "connecting";
 	mySide?: PlayerSide;
 	isPreparing?: boolean;
+	initialMessages?: any[];
 }
 
-function MatchBoard({ roomId, socket, wsStatus = "disconnected", mySide = "sente", isPreparing = false }: MatchBoardProps) {
+function MatchBoard({ roomId, socket, wsStatus = "disconnected", mySide = "sente", isPreparing = false, initialMessages }: MatchBoardProps) {
 	const router = useRouter();
 	const user = useUser();
 	const { data: session } = useSession();
@@ -226,6 +227,7 @@ function MatchBoard({ roomId, socket, wsStatus = "disconnected", mySide = "sente
 								socket={socket}
 								roomId={roomId}
 								mySide={mySide}
+								initialMessages={initialMessages}
 							/>
 						)}
 

--- a/nextjs/hooks/useGameLogic.ts
+++ b/nextjs/hooks/useGameLogic.ts
@@ -1,6 +1,7 @@
 import { useCallback, useReducer, useEffect, useMemo } from "react";
 import { useLegalMoves } from "./useLegalMoves";
 import { gameReducer, GameAction } from "./reducers/gameReducer";
+import { PlayerSide } from "@/types/game";
 import {
 	PieceData,
 	GameState,
@@ -15,7 +16,7 @@ import {
 	type PieceInfo
 } from "@torassen/shogi-logic";
 
-export function useGameLogic(mySide: "sente" | "gote" | "spectator") {
+export function useGameLogic(mySide: PlayerSide) {
 	function deepCopyBoard(board: PieceData[][]): PieceData[][] {
 		return board.map((row) => row.map((cell) => (cell ? { ...cell } : null)));
 	}

--- a/nextjs/hooks/useShogiGame.ts
+++ b/nextjs/hooks/useShogiGame.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Socket } from "socket.io-client";
 import { useGameLogic } from "./useGameLogic";
+import { PlayerSide } from "@/types/game";
 import { Pos, UIBoard, sfenToUIBoard, PieceType, type Move } from "@torassen/shogi-logic";
 
 const KANJI_TO_PIECE_TYPE: Record<string, PieceType> = {
@@ -16,7 +17,7 @@ const KANJI_TO_PIECE_TYPE: Record<string, PieceType> = {
 export function useShogiGame(
 	socket: Socket | null | undefined,
 	roomId: string | undefined,
-	mySide: "sente" | "gote" | "spectator",
+	mySide: PlayerSide,
 	wsStatus: "connected" | "disconnected" | "connecting"
 ) {
 	const router = useRouter();

--- a/nextjs/types/game.ts
+++ b/nextjs/types/game.ts
@@ -1,0 +1,1 @@
+export type PlayerSide = "sente" | "gote" | "spectator";

--- a/ws-server/src/index.ts
+++ b/ws-server/src/index.ts
@@ -1,13 +1,13 @@
 import { Server, Socket } from "socket.io";
 import http from "http";
-import {apply} from "@torassen/shogi-logic"
+import { apply } from "@torassen/shogi-logic"
 
 const PORT = 3001;
 
 interface RoomState {
 	hostSocketId: string;
 	hostUserId?: string;
-	players: { socketId: string; userId?: string,side: "b" | "w" }[];
+	players: { socketId: string; userId?: string, side: "b" | "w" }[];
 	spectators: string[];
 	sfen: string;
 	status: "waiting" | "playing";
@@ -32,8 +32,8 @@ const io = new Server(httpServer, {
 io.on("connection", (socket: Socket) => {
 	console.log(`[WS] Client connected: ${socket.id}`);
 
-	socket.on("joinRoom", (data: { roomId: string;isPlayer:boolean, userId?: string }) => {
-		const { roomId,isPlayer, userId } = data;
+	socket.on("joinRoom", (data: { roomId: string; isPlayer: boolean, userId?: string }) => {
+		const { roomId, isPlayer, userId } = data;
 		console.log(`[WS] joinRoom: ${roomId} by ${socket.id} (user: ${userId})`);
 
 		let room = rooms.get(roomId);
@@ -42,35 +42,35 @@ io.on("connection", (socket: Socket) => {
 			room = {
 				hostSocketId: socket.id,
 				hostUserId: userId,
-				players: [{ socketId: socket.id, userId,side: "b" }],
+				players: [{ socketId: socket.id, userId, side: "b" }],
 				spectators: [],
 				sfen: INITIAL_SFEN,
 				status: "waiting",
 			};
 			rooms.set(roomId, room);
-		} else if(isPlayer){
-            const existingPlayerIndex = room.players.findIndex(
-                (p) => p.userId && p.userId === userId
+		} else if (isPlayer) {
+			const existingPlayerIndex = room.players.findIndex(
+				(p) => p.userId && p.userId === userId
 			);
-            if (existingPlayerIndex !== -1) {
-                room.players[existingPlayerIndex].socketId = socket.id;
-            } else if (room.players.length < 2) {
-                const occupiedSide = room.players[0].side;
-                const newSide = occupiedSide === "b" ? "w" : "b";
-                room.players.push({ socketId: socket.id, userId, side: newSide });
+			if (existingPlayerIndex !== -1) {
+				room.players[existingPlayerIndex].socketId = socket.id;
+			} else if (room.players.length < 2) {
+				const occupiedSide = room.players[0].side;
+				const newSide = occupiedSide === "b" ? "w" : "b";
+				room.players.push({ socketId: socket.id, userId, side: newSide });
 				if (room.players.length === 2) {
-                room.status = "playing";
-           		}
+					room.status = "playing";
+				}
 			} else {
-                if (!room.spectators.includes(socket.id))
-                    room.spectators.push(socket.id);
-            }
-        }else {
-            console.log(`[WS] Spectator joined: ${socket.id}`);
-            if (!room.spectators.includes(socket.id)) {
-                room.spectators.push(socket.id);
-            }
-        }
+				if (!room.spectators.includes(socket.id))
+					room.spectators.push(socket.id);
+			}
+		} else {
+			console.log(`[WS] Spectator joined: ${socket.id}`);
+			if (!room.spectators.includes(socket.id)) {
+				room.spectators.push(socket.id);
+			}
+		}
 
 		socket.join(roomId);
 
@@ -167,7 +167,7 @@ io.on("connection", (socket: Socket) => {
 				);
 			}
 
-			room.sfen = apply(room.sfen,data);
+			room.sfen = apply(room.sfen, data);
 
 			socket.to(data.roomId).emit("moveMade", {
 				from: data.from,
@@ -178,6 +178,11 @@ io.on("connection", (socket: Socket) => {
 		}
 	);
 
+	socket.on("chat", (data: { roomId: string; message: any }) => {
+		console.log(`[WS] Chat in room ${data.roomId} from ${socket.id}`);
+		socket.to(data.roomId).emit("chat", data.message);
+	});
+
 	socket.on("resign_match", (data: { roomId: string }) => {
 		console.log(`[WS] resign_match received for room: ${data.roomId} from ${socket.id}`);
 		const room = rooms.get(data.roomId);
@@ -187,18 +192,18 @@ io.on("connection", (socket: Socket) => {
 		}
 
 		const loserIdx = room.players.findIndex((p) => p.socketId === socket.id);
-	if (loserIdx === -1) return;
+		if (loserIdx === -1) return;
 
-	const loserSide = room.players[loserIdx].side; 
-	const winnerSide = loserSide === "b" ? "gote" : "sente";
+		const loserSide = room.players[loserIdx].side;
+		const winnerSide = loserSide === "b" ? "gote" : "sente";
 
-	const winnerName = winnerSide === "gote" ? "後手" : "先手";
-	const loserName = loserSide === "w" ? "後手" : "先手";
+		const winnerName = winnerSide === "gote" ? "後手" : "先手";
+		const loserName = loserSide === "w" ? "後手" : "先手";
 
-	io.to(data.roomId).emit("match_ended", {
-		winner: winnerSide,
-		message: `${loserName}が投了しました。${winnerName}の勝ちです。`,
-	});
+		io.to(data.roomId).emit("match_ended", {
+			winner: winnerSide,
+			message: `${loserName}が投了しました。${winnerName}の勝ちです。`,
+		});
 	});
 
 	socket.on("disconnect", () => {

--- a/ws-server/src/index.ts
+++ b/ws-server/src/index.ts
@@ -11,6 +11,7 @@ interface RoomState {
 	spectators: string[];
 	sfen: string;
 	status: "waiting" | "playing";
+	messages: any[];
 }
 
 const INITIAL_SFEN = "rbsgk/4p/5/P4/KGSBR b - 1";
@@ -46,6 +47,7 @@ io.on("connection", (socket: Socket) => {
 				spectators: [],
 				sfen: INITIAL_SFEN,
 				status: "waiting",
+				messages: [],
 			};
 			rooms.set(roomId, room);
 		} else if (isPlayer) {
@@ -84,6 +86,7 @@ io.on("connection", (socket: Socket) => {
 				userId: p.userId,
 				side: p.side,
 			})),
+			messages: room.messages,
 		});
 	});
 
@@ -100,6 +103,7 @@ io.on("connection", (socket: Socket) => {
 					userId: p.userId,
 					side: p.side,
 				})),
+				messages: room.messages,
 			});
 		} else {
 			socket.emit("roomState", {
@@ -180,6 +184,10 @@ io.on("connection", (socket: Socket) => {
 
 	socket.on("chat", (data: { roomId: string; message: any }) => {
 		console.log(`[WS] Chat in room ${data.roomId} from ${socket.id}`);
+		const room = rooms.get(data.roomId);
+		if (room) {
+			room.messages.push(data.message);
+		}
 		socket.to(data.roomId).emit("chat", data.message);
 	});
 
@@ -235,6 +243,7 @@ io.on("connection", (socket: Socket) => {
 							userId: p.userId,
 							side: p.side
 						})),
+						messages: room.messages,
 					});
 
 					io.to(roomId).emit("playerLeft", { socketId: socket.id });


### PR DESCRIPTION
# [Summary]
- こうたの作ったPR(https://github.com/Anya-Stella/transcendence/pull/89
- を進化させた
- リロード時に会話も保持されるようにWS側にmessagesを保持
- sessionから名前をとってきてheaderとmessageの属性に反映
- typeをexportしてリファクタリング
- マッチ画面から対局画面にソケットを引き継げないのが課題。
そこを対応したのをこれから出すかもなので、これは最低限ちゃんと動く会話機能

<img width="944" height="1082" alt="スクリーンショット 2026-04-13 23 39 12" src="https://github.com/user-attachments/assets/4c7dca91-31b8-4617-8a1a-3183239be440" />

